### PR TITLE
Production hardening: action outputs, retries, URL guard, watched attributes, once-per-record, wait-until, signed webhooks, authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to `packstub/filament-flow` are documented here.
 
 ## Unreleased
 
+### Added
+
+- **Action outputs**: an action can call `$this->output([...])`; the nodes after it on the same branch read it as `{{ last.* }}` and `{{ outputs.<node id>.* }}`. `HttpRequest` exposes `status`, `ok`, `body` (decoded JSON) and `headers`; `UpdateRecord` exposes `changes`. Outputs are stored on the step log (up to `max_output_bytes`) and shown in the run details.
+- **Per-node error handling**: every action node has an *Error handling* section — retries (with a pause between them) and *Fail the run* / *Log it and continue* after the last failure. Stored as `_retries`, `_retry_after` and `_on_error` in the node config; the runner strips them before calling the action.
+- **Placeholder filters**: `{{ value | date:Y-m-d }}`, `upper`, `lower`, `title`, `trim`, `truncate:<n>`, `number:<decimals>`, `default:<value>`, `json`, `count`, `join:<glue>`, `first`, `last`; `Placeholders::raw()` / `isSingle()` for nodes that need a typed value.
+- **Record updated → "Only when these attributes change"**: the trigger fires only when one of the listed attributes is in `changes`.
+- **"Run once per record"** on the record triggers; runs store `subject_type` / `subject_id` (the record they started for), searchable in the Runs tab.
+- **Wait until a date**: the Wait action has a *Until a date from the payload* mode with an offset before / after (`1 day before {{ model.starts_at }}`).
+- **Webhook signatures**: optional HMAC-SHA256 signing secret and signature header per webhook node; unsigned or mis-signed requests get `401`.
+- **Schedule timezone** per Schedule trigger.
+- **Run again** action on finished runs (`WorkflowRun::rebuildPayload()` re-fetches the records from the stored context).
+- **Definition validation** before saving an active workflow: a trigger must exist, every node must be connected, required settings must be filled (`DefinitionValidator`; `FlowBuilder::withoutValidation()` to opt out).
+- **Authorization**: `FlowPlugin::make()->authorize(fn () => ...)` and the `packstub-flow.gate` config key gate the Workflows resource, on top of any `Workflow` policy.
+- `http` config section (`timeout`, `retry_after_ms`, `block_private_networks`, `allowed_hosts`), `queue.timeout`, `max_output_bytes`, `webhooks.redacted_headers`, `gate`.
+- `packstub-flow:prune` is scheduled daily when `register_schedule` is on and `prune_runs_after_days` is set.
+- Step log entries carry `status` (`ok` / `retry` / `failed`), `duration_ms` and `output`; the step that fails a run carries its error message; the run details modal shows all three.
+
+### Changed
+
+- **Outgoing requests are guarded**: `HttpRequest` and `SendSlackMessage` refuse URLs that are not `http(s)` or whose host resolves to a private / reserved address (`UrlGuard`), unless `http.block_private_networks` is off or the host is in `http.allowed_hosts`. Requests have a timeout (15 s default) and per-node retries; placeholder values in the URL are URL-encoded.
+- **HTTP JSON bodies are built safely**: placeholders inside JSON strings are escaped, bare placeholders become the raw value; a value can no longer add keys to the body.
+- **`UpdateRecord` respects `$fillable` / `$guarded`** and fails the run naming a guarded attribute; the new *Bypass mass-assignment protection* toggle restores `forceFill()`. A value that is exactly one placeholder keeps its type.
+- **Webhook payloads drop credential headers** (`authorization`, `cookie`, `x-api-key`, signature headers, …) before they are stored on the run.
+- **Hidden model attributes** (`$hidden`) resolve to nothing in placeholders.
+- **Record-trigger dispatch is cached**: model events no longer query the triggers table unless an active workflow has a trigger of that type (cache flushed on every workflow save / delete, refreshed per process every 60 s).
+- **Jobs** implement `ShouldQueueAfterCommit`, have `tries = 1` and a configurable `timeout`; a resume job for a run another branch has failed does nothing; step appends are re-read under a lock so concurrent resumes do not overwrite each other.
+- A join node reached by two branches runs once (it used to run once per branch); the payload — and with it the outputs — now travels per branch.
+- The trigger rows are re-synced inside a transaction when a workflow is saved.
+- Migration: `subject_type` / `subject_id` on the runs table and indexes on `started_at`, `(workflow_id, started_at)` and the subject.
+
 ## 1.0.0 — 2026-09-02
 
 First public release. The plugin started life as the private `xlited/laravel-flow` prototype and was rebuilt as a Packstub Filament plugin.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ Visual workflow automations for your Filament panel: draw triggers, conditions a
 ## Features
 
 - **[Visual builder](#the-builder)** — a drag-and-drop canvas inside a Filament resource: add nodes from a sidebar, connect them, branch on true / false, and edit each node's settings in a slide-over built from Filament form components.
-- **[Triggers](#triggers)** — record created / updated / deleted, user registered, any Laravel event, a cron schedule, a webhook, a manual run, or a call from another workflow.
+- **[Triggers](#triggers)** — record created / updated / deleted (optionally only when chosen attributes change, or once per record), user registered, any Laravel event, a cron schedule with its own timezone, a signed webhook, a manual run, or a call from another workflow.
 - **[Conditions](#conditions)** — compare a record attribute or any two values with fifteen operators, or check the time of day.
-- **[Actions](#actions)** — send an email, a Filament database notification or a Slack message, call an HTTP endpoint, update the record, wait, call another workflow, or write to the log.
-- **[Placeholders](#placeholders)** — `{{ model.name }}`, `{{ webhook.order.id }}`, `{{ event.carrier }}` and friends, resolved from the run's payload wherever you type text.
-- **[Run history](#runs)** — every run is stored with its status, trigger, payload summary, a step-by-step log and any error, browsable from a Runs tab; a **Run now** button for quick checks.
-- **[Queue & scheduling](#queue--scheduling)** — run workflows inline or on your queue, pause them for minutes or days with a Wait step, and start them from cron expressions with one scheduler entry.
-- **[Webhooks](#webhooks)** — a tokenised POST endpoint per workflow that answers `202 Accepted` and exposes the request body to your nodes.
+- **[Actions](#actions)** — send an email, a Filament database notification or a Slack message, call an HTTP endpoint and use its response in later nodes, update the record, wait for a duration or until a date from the payload, call another workflow, or write to the log. Every action has retries and a continue-on-error switch.
+- **[Placeholders](#placeholders)** — `{{ model.name }}`, `{{ webhook.order.id }}`, `{{ last.body.id }}` and friends, with filters such as `| date:Y-m-d`, `| upper` and `| default:none`, resolved from the run's payload wherever you type text.
+- **[Run history](#runs)** — every run is stored with its status, trigger, record, payload summary, a step-by-step log with timings and outputs, and any error, browsable from a Runs tab; **Run now** and **Run again** buttons for quick checks and repeats.
+- **[Queue & scheduling](#queue--scheduling)** — run workflows inline or on your queue (dispatched after your transaction commits), pause them for minutes or days with a Wait step, and start them from cron expressions with one scheduler entry.
+- **[Webhooks](#webhooks)** — a tokenised, optionally HMAC-signed POST endpoint per workflow that answers `202 Accepted` and exposes the request body to your nodes.
+- **Safe by default** — outgoing requests cannot reach private networks unless you allow it, record updates respect mass-assignment rules, credential headers never reach the run log, hidden model attributes never reach a template, and the Workflows resource can sit behind a policy, a Gate ability or a callback.
 - **[Extensible](#extending)** — write your own trigger, action or condition class with a Filament form schema and register it on the plugin, in the config, or with `Flow::register()`.
 - **Dark mode ready** and **translatable** — the canvas follows Filament's theme, and every string, node name and description lives in a language file.
 

--- a/config/packstub-flow.php
+++ b/config/packstub-flow.php
@@ -55,6 +55,8 @@ return [
         'enabled' => (bool) env('PACKSTUB_FLOW_QUEUE', false),
         'connection' => env('PACKSTUB_FLOW_QUEUE_CONNECTION'),
         'queue' => env('PACKSTUB_FLOW_QUEUE_NAME'),
+        // Seconds a queued run (or a resumed branch) may take before the worker kills it.
+        'timeout' => (int) env('PACKSTUB_FLOW_QUEUE_TIMEOUT', 300),
     ],
 
     /*
@@ -68,6 +70,30 @@ return [
     */
 
     'max_steps' => 1000,
+
+    // An action's output (an HTTP response, for example) is kept on the run's
+    // step log up to this many bytes; larger outputs are stored as a preview.
+    'max_output_bytes' => 16384,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Outgoing HTTP
+    |--------------------------------------------------------------------------
+    |
+    | Applies to the "HTTP request" and "Send Slack message" actions. Private
+    | and reserved addresses (localhost, 10.x, 192.168.x, 169.254.x, ...)
+    | are refused unless block_private_networks is off. Set allowed_hosts to
+    | restrict requests to a list of hosts ("api.example.com",
+    | "*.example.com"); when it is not empty only those hosts are allowed.
+    |
+    */
+
+    'http' => [
+        'timeout' => (int) env('PACKSTUB_FLOW_HTTP_TIMEOUT', 15),
+        'retry_after_ms' => 500,
+        'block_private_networks' => (bool) env('PACKSTUB_FLOW_HTTP_BLOCK_PRIVATE', true),
+        'allowed_hosts' => [],
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -97,6 +123,8 @@ return [
         'enabled' => true,
         'prefix' => 'flow/webhooks',
         'middleware' => ['api', 'throttle:60,1'],
+        // Request headers that are dropped before the payload is stored on the run.
+        'redacted_headers' => ['authorization', 'proxy-authorization', 'cookie', 'x-api-key', 'x-auth-token', 'x-signature', 'x-hub-signature', 'x-hub-signature-256'],
     ],
 
     /*
@@ -173,5 +201,19 @@ return [
     */
 
     'prune_runs_after_days' => 30,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization
+    |--------------------------------------------------------------------------
+    |
+    | Workflows can call URLs, send mail and update records, so who may
+    | manage them matters. Register a policy for the Workflow model, call
+    | FlowPlugin::make()->authorize(fn () => ...), or name a Gate ability
+    | here that every panel user must pass to see the Workflows resource.
+    |
+    */
+
+    'gate' => env('PACKSTUB_FLOW_GATE'),
 
 ];

--- a/database/migrations/create_flow_tables.php.stub
+++ b/database/migrations/create_flow_tables.php.stub
@@ -34,6 +34,8 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('workflow_id')->constrained($workflows)->cascadeOnDelete();
             $table->string('trigger_type')->nullable();
+            $table->string('subject_type')->nullable();
+            $table->string('subject_id', 64)->nullable();
             $table->string('status', 16)->index();
             $table->json('context')->nullable();
             $table->json('steps')->nullable();
@@ -42,6 +44,10 @@ return new class extends Migration
             $table->timestamp('started_at')->nullable();
             $table->timestamp('finished_at')->nullable();
             $table->timestamps();
+
+            $table->index(['workflow_id', 'started_at']);
+            $table->index(['workflow_id', 'subject_type', 'subject_id'], 'flow_runs_subject_index');
+            $table->index('started_at');
         });
     }
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -50,9 +50,24 @@ Calls any URL.
 | URL | Placeholders allowed: `https://api.example.com/hooks/{{ model.id }}` |
 | Headers | Key / value pairs; placeholders allowed in values |
 | JSON body | Sent as JSON for every method except `GET`. Must be valid JSON once placeholders are masked, which the form checks; placeholders allowed in values and as bare values |
+| Timeout | Seconds before the request is abandoned; empty uses `http.timeout` from the config (15 s) |
+| Retries on connection errors | Extra attempts (0–5) when the request cannot be sent or times out, half a second apart |
 | Fail the run on a 4xx / 5xx response | On by default. Turn off to continue whatever the response |
 
-Placeholders inside a quoted JSON string stay strings (`"total": "{{ model.total }}"` sends `"12.5"`). The settings form requires the body to be valid JSON with placeholders in quotes. Definitions created from code may also use a placeholder as a bare value (`"total": {{ model.total }}`): it is filled in before the body is decoded, so numbers, booleans and arrays keep their type. A body that is not valid JSON at run time fails the run. The response body is not exposed to later nodes.
+Placeholders inside a quoted JSON string stay strings and are escaped, so a value containing quotes cannot add keys to the body (`"note": "{{ model.note }}"` is always one string). A bare placeholder (`"total": {{ model.total }}`, `"customer": {{ model }}`) becomes the raw value — number, boolean, array, or a model's attributes — so types survive. Placeholder values in the URL are URL-encoded. A body that is not valid JSON at run time fails the run.
+
+The response is available to the nodes after the request:
+
+| Placeholder | |
+| --- | --- |
+| `{{ last.status }}` | The HTTP status code |
+| `{{ last.ok }}` | `1` for 2xx, `0` otherwise |
+| `{{ last.body.id }}` | The decoded JSON body (or the raw text when it is not JSON) |
+| `{{ last.headers.content-type }}` | Response headers |
+
+`last` is replaced by the output of the next action that produces one; `{{ outputs.<node id>.body.id }}` reaches a specific request. See [Placeholders](placeholders.md#outputs-of-earlier-actions).
+
+Destinations are checked before the request is sent: private and reserved addresses (`localhost`, `10.x`, `192.168.x`, `169.254.x`, …) are refused, and `http.allowed_hosts` in the config can restrict requests to a list of hosts. See [Configuration](configuration.md#outgoing-http).
 
 ## Update record
 
@@ -60,10 +75,11 @@ Sets attributes on the record that started the run — the `model` in the payloa
 
 | Setting | |
 | --- | --- |
-| Attributes | Attribute / value pairs; placeholders allowed in values |
+| Attributes | Attribute / value pairs; placeholders allowed in values. A value that is exactly one placeholder keeps its type (`{{ webhook.total }}` writes a number, `{{ missing }}` writes `null`) |
 | Save without firing events | On by default |
+| Bypass mass-assignment protection | Off by default |
 
-Attributes are set with `forceFill()`, so they do not need to be fillable. With **Save without firing events** on, the record is saved with `saveQuietly()`: no Eloquent events, no observers, and no **Record updated** trigger — which keeps a workflow that reacts to updates from starting itself again. Turn it off when you want observers and other workflows to see the change.
+Attributes go through the model's `$fillable` / `$guarded` rules: writing a guarded attribute fails the run with a message naming it. Turn on **Bypass mass-assignment protection** to use `forceFill()` instead — only when everyone who can edit workflows may write any column. The action exposes the saved changes as `{{ last.changes.status }}`. With **Save without firing events** on, the record is saved with `saveQuietly()`: no Eloquent events, no observers, and no **Record updated** trigger — which keeps a workflow that reacts to updates from starting itself again. Turn it off when you want observers and other workflows to see the change.
 
 The action fails the run when the payload has no record, and does nothing when no attributes are configured.
 
@@ -73,8 +89,12 @@ Pauses the run and continues the nodes after it later, through the queue.
 
 | Setting | |
 | --- | --- |
-| Duration | A whole number, at least 1 |
-| Unit | Seconds, Minutes (default), Hours or Days |
+| Wait | **For a duration** (default) or **Until a date from the payload** |
+| Duration / Unit | The length of the wait, or the offset from the date: Seconds, Minutes (default), Hours or Days |
+| Date | Until mode only: a placeholder or a date, e.g. `{{ model.starts_at }}` or `{{ model.due_at }}` |
+| Offset | Until mode only: continue that duration **before** or **after** the date |
+
+"1 day before `{{ model.starts_at }}`" sends an appointment reminder; "3 days after `{{ model.due_at }}`" is a dunning step. A date already in the past (after the offset) continues immediately, and a date that cannot be read from the payload does too.
 
 When the runner reaches a Wait, it records the nodes connected to the Wait's output, marks the run **Waiting**, and dispatches a delayed job that resumes them once the time has passed. A Wait with nothing connected after it finishes the run immediately. Everything about how this interacts with your queue — the graph snapshot, several Waits in one run, the `sync` driver — is in [Queue & scheduling](queue-and-scheduling.md#wait-steps).
 

--- a/docs/building-workflows.md
+++ b/docs/building-workflows.md
@@ -36,6 +36,7 @@ The slide-over is a Filament form:
 
 - **General** — label (required, up to 80 characters) and description (up to 255).
 - **Settings** — the node's own fields, e.g. the record type of a trigger or the recipient and subject of an email. Fields are validated when you press **Apply**; a cron expression, a JSON body or an event class that does not exist is rejected right there.
+- **Error handling** — action nodes only: retries, the pause between them, and whether the last failure fails the run or is logged and skipped. See [Runs](runs.md#failures).
 - **Placeholders** — a collapsed section listing the `{{ placeholders }}` that node understands. See [Placeholders](placeholders.md).
 
 **Apply** writes the values back to the node on the canvas. They are stored when you save the workflow.
@@ -49,6 +50,8 @@ Right-click a node for **Settings**, **Duplicate** and **Delete**. A duplicate k
 The canvas is a form field; the usual **Save** (or **Create**) button of the page stores the graph together with the name, description and **Active** toggle. After creating a workflow you land on its edit page.
 
 Only active workflows run. New workflows start inactive, and a copy made with the table's **Replicate** action is inactive too, so you can finish a draft safely before switching it on.
+
+Saving an **active** workflow checks the definition first and refuses it with a message per problem: no trigger node, a node nothing leads to, or a required setting left empty (a node dropped on the canvas whose settings were never opened). Inactive drafts are only checked for nodes whose class is no longer registered.
 
 When a workflow is saved, its trigger nodes are mirrored into the `flow_workflow_triggers` table. That is how the dispatcher finds candidate workflows for an incoming event with one indexed query — you never edit that table yourself.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,18 +86,40 @@ The user model used by **Send notification** is `auth.providers.users.model`.
     'enabled' => (bool) env('PACKSTUB_FLOW_QUEUE', false),
     'connection' => env('PACKSTUB_FLOW_QUEUE_CONNECTION'),
     'queue' => env('PACKSTUB_FLOW_QUEUE_NAME'),
+    'timeout' => (int) env('PACKSTUB_FLOW_QUEUE_TIMEOUT', 300),
 ],
 ```
 
-`enabled` pushes every triggered run onto the queue; `connection` and `queue` apply to run jobs and to the resume jobs of **Wait** steps (which use the queue regardless). See [Queue & scheduling](queue-and-scheduling.md).
+`enabled` pushes every triggered run onto the queue; `connection` and `queue` apply to run jobs and to the resume jobs of **Wait** steps (which use the queue regardless); `timeout` is the job timeout in seconds. See [Queue & scheduling](queue-and-scheduling.md).
 
 ### Execution limits
 
 ```php
 'max_steps' => 1000,
+'max_output_bytes' => 16384,
 ```
 
-A run fails once it has visited more than this many nodes. Cycles fail on their own, whatever the limit — see [Runs](runs.md#safety-guards).
+A run fails once it has visited more than `max_steps` nodes. Cycles fail on their own, whatever the limit — see [Runs](runs.md#safety-guards). An action's output (an HTTP response, say) is kept on the step log up to `max_output_bytes`; larger outputs are stored as a truncated preview, though the nodes after it still receive the whole value.
+
+### Outgoing HTTP
+
+```php
+'http' => [
+    'timeout' => (int) env('PACKSTUB_FLOW_HTTP_TIMEOUT', 15),
+    'retry_after_ms' => 500,
+    'block_private_networks' => (bool) env('PACKSTUB_FLOW_HTTP_BLOCK_PRIVATE', true),
+    'allowed_hosts' => [],
+],
+```
+
+Applies to the **HTTP request** and **Send Slack message** actions.
+
+| Key | |
+| --- | --- |
+| `timeout` | Default request timeout in seconds; a node can set its own |
+| `retry_after_ms` | Pause between the retries a node asks for |
+| `block_private_networks` | Refuses URLs whose host is, or resolves to, a loopback, private, link-local or otherwise reserved address (`localhost`, `127.0.0.1`, `10.0.0.0/8`, `192.168.0.0/16`, `169.254.169.254`, `::1`, …). Only `http` and `https` are ever allowed. Turn off when workflows must reach services on your private network — and make sure only trusted users can edit workflows |
+| `allowed_hosts` | When not empty, requests may only go to these hosts: exact names or `*.example.com` wildcards. Everything else is refused, whatever `block_private_networks` says |
 
 ### Schedule
 
@@ -121,7 +143,8 @@ Adds `packstub-flow:cron` to Laravel's scheduler every minute (`withoutOverlappi
 | --- | --- |
 | `enabled` | `false` removes the route entirely; webhook nodes then never fire |
 | `prefix` | The route is `POST {prefix}/{workflow}/{token}`, named `packstub-flow.webhook`. The **Webhook** trigger's settings show the resulting URL |
-| `middleware` | Applied to the route. Keep a throttle; add your own middleware (an IP allow-list, a signature check) here |
+| `middleware` | Applied to the route. Keep a throttle; add your own middleware (an IP allow-list) here |
+| `redacted_headers` | Request headers removed before the payload is stored on the run: `authorization`, `cookie`, `x-api-key`, the signature headers, … |
 
 The route is registered by the package service provider, outside any panel, so it is not affected by the panel's middleware or authentication.
 
@@ -186,7 +209,21 @@ Defaults for the Workflows resource, overridden per panel by `navigationGroup()`
 'prune_runs_after_days' => 30,
 ```
 
-How old a finished run must be before `packstub-flow:prune` deletes it. See [Runs](runs.md#packstub-flowprune).
+How old a finished run must be before `packstub-flow:prune` deletes it. With `register_schedule` on, the command is scheduled daily; set the value to `null` to keep runs forever (and not schedule the command). See [Runs](runs.md#packstub-flowprune).
+
+### Authorization
+
+```php
+'gate' => env('PACKSTUB_FLOW_GATE'),
+```
+
+Workflows can call URLs, send mail and update records, so decide who may manage them. Three layers, all optional and combined:
+
+- a **policy** on the `Workflow` model (`WorkflowPolicy`, or `Gate::policy(Workflow::class, ...)`) — Filament applies it to the resource pages and actions as usual;
+- the plugin's `authorize()` callback — `FlowPlugin::make()->authorize(fn () => auth()->user()->isAdmin())` hides the resource when it returns `false`;
+- a **Gate ability** named here — every panel user must pass it to see the resource.
+
+Without any of them, every user who can access the panel can manage every workflow.
 
 ## The canvas field
 
@@ -201,7 +238,7 @@ FlowBuilder::make('definition')
     ->columnSpanFull()
 ```
 
-The field's state is the `{nodes, edges}` structure described in [Building workflows](building-workflows.md#how-a-definition-is-stored); the model attribute should be cast to `array`.
+The field's state is the `{nodes, edges}` structure described in [Building workflows](building-workflows.md#how-a-definition-is-stored); the model attribute should be cast to `array`. The field validates the definition before it is saved — a trigger must exist, every other node must be connected, required settings must be filled — when the form has an `is_active` field that is on. `->withoutValidation()` skips those checks.
 
 ## Translations and views
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -20,7 +20,7 @@ The `config` array is exactly what the form produced; the `payload` array is wha
 
 ## Actions
 
-Extend `Packstub\Flow\Nodes\Action` and implement `handle(array $config, array $payload): void`. Throw to fail the run; return to continue.
+Extend `Packstub\Flow\Nodes\Action` and implement `handle(array $config, array $payload): void`. Throw to fail the run (or let the node's retry / continue-on-error settings deal with it); return to continue. Call `$this->output([...])` before returning to expose values to the nodes after it as `{{ last.* }}` and `{{ outputs.<node id>.* }}` — see [Placeholders](placeholders.md#outputs-of-earlier-actions).
 
 ```php
 namespace App\Flow\Actions;
@@ -68,6 +68,8 @@ class AssignToTeam extends Action
         }
 
         $record->forceFill(['team_id' => $config['team_id']])->saveQuietly();
+
+        $this->output(['team_id' => $config['team_id']]);
     }
 }
 ```

--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -20,7 +20,44 @@ A placeholder is a path of letters, digits, `_`, `-` and dots between double bra
 | `{{ event.order.reference }}` | A public property of the event, then an attribute of the model inside it |
 | `{{ headers.x-signature }}` | A request header of a webhook call |
 
-A path that resolves to nothing renders as an empty string — the run does not fail. Text without `{{` is returned untouched.
+A path that resolves to nothing renders as an empty string — the run does not fail. Text without `{{` is returned untouched. Attributes in a model's `$hidden` list (passwords, tokens) always resolve to nothing, even through a relationship.
+
+## Filters
+
+A value can be passed through filters with `|`, several in a row:
+
+```text
+{{ model.created_at | date:Y-m-d }}
+{{ model.name | upper }}
+{{ webhook.note | default:none }}
+{{ model.total | number:2 }}
+{{ tags | join:, | truncate:80 }}
+```
+
+| Filter | |
+| --- | --- |
+| `date:<format>` | Formats a date (`Carbon`, a `DateTime` or a parseable string) with a PHP date format |
+| `upper`, `lower`, `title`, `trim` | Text transforms |
+| `truncate:<n>` | Cuts to *n* characters and adds `...` |
+| `number:<decimals>` | `number_format()` with that many decimals |
+| `default:<value>` | Uses the value when the placeholder is empty |
+| `json` | JSON of the value (a model becomes its attributes) |
+| `count` | Number of items in an array or collection |
+| `join:<glue>` | Joins an array or collection; spaces around the glue are trimmed |
+| `first`, `last` | First or last item of an array or collection |
+
+An unknown filter leaves the value unchanged; a filter that cannot be applied (a date that does not parse) does too.
+
+## Outputs of earlier actions
+
+Some actions expose a result to the nodes after them on the same branch:
+
+| Placeholder | |
+| --- | --- |
+| `{{ last.status }}`, `{{ last.body.id }}` | The output of the most recent action that produced one — an **HTTP request**'s status, body and headers, or the `changes` of **Update record** |
+| `{{ outputs.<node id>.body.id }}` | The output of a specific node, by its id (shown in the definition; see [Building workflows](building-workflows.md#how-a-definition-is-stored)) |
+
+Outputs follow the branch: a node on another branch leaving the same trigger does not see them. They are stored on the run's step log (up to `max_output_bytes`) and shown in the run details. Your own actions expose values with `$this->output([...])` — see [Extending](extending.md#actions).
 
 ## Aliases
 

--- a/docs/queue-and-scheduling.md
+++ b/docs/queue-and-scheduling.md
@@ -31,6 +31,8 @@ With the queue enabled, a `Packstub\Flow\Jobs\RunWorkflowJob` is dispatched per 
 
 The choice can be made per call: `Flow::run($workflow, $payload, queue: false)` forces a synchronous run, `queue: true` forces a job.
 
+Both jobs are dispatched **after the surrounding database transaction commits** (`ShouldQueueAfterCommit`), so a run never sees a record that is rolled back. They have `tries = 1` — a run that fails is recorded as failed rather than retried, since retrying would repeat the actions that already ran; use the per-node retries in a node's **Error handling** settings instead — and a `timeout` from `queue.timeout` (300 s by default).
+
 The job re-checks that the workflow is still active when it runs. Eloquent models in the payload are stored as class + key (+ the attributes they had) and fetched fresh when the job runs; a record that has been deleted in the meantime is rebuilt from the stored attributes so placeholders keep working. Other objects in the payload (an event object, for instance) are serialised by the queue as usual, so they need to be serialisable — Laravel's `SerializesModels` on the event takes care of models inside it.
 
 ## Wait steps
@@ -54,7 +56,7 @@ The connection and queue name from the config apply to resume jobs too.
 
 ## Schedules
 
-Workflows with a **Schedule** trigger are started by the `packstub-flow:cron` command, which dispatches the trigger with the current time; every active workflow whose cron expression is due at that minute starts (in the application timezone).
+Workflows with a **Schedule** trigger are started by the `packstub-flow:cron` command, which dispatches the trigger with the current time; every active workflow whose cron expression is due at that minute starts, in the timezone set on the trigger (the application timezone by default).
 
 With `register_schedule` on (the default), the plugin adds the command to Laravel's scheduler:
 
@@ -76,6 +78,8 @@ use Illuminate\Support\Facades\Schedule;
 Schedule::command('packstub-flow:cron')->everyMinute()->onOneServer();
 ```
 
-Scheduled runs follow the same sync / queued rule as every other run: with the queue enabled, the cron command only dispatches jobs and returns quickly.
+Scheduled runs follow the same sync / queued rule as every other run: with the queue enabled, the cron command only dispatches jobs and returns quickly. Without it, due workflows run inside the scheduler tick one after another, under `withoutOverlapping()` — fine for a few quick workflows, and a reason to enable the queue once schedules do real work.
+
+With `register_schedule` on and a `prune_runs_after_days` value, `packstub-flow:prune` is scheduled daily too.
 
 Next: [Extending](extending.md).

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -20,15 +20,16 @@ Every time a workflow starts, a `WorkflowRun` row is created and updated step by
 | Column | |
 | --- | --- |
 | `trigger_type` | The class of the trigger node the run started from |
+| `subject_type`, `subject_id` | The record the run started for (the `model` in the payload), used by "Run once per record" and shown in the Runs tab |
 | `context` | A JSON summary of the payload: models become `{"type": "App\\Models\\Order", "key": 42}`, other objects `{"type": "App\\Events\\OrderShipped"}`, scalars and arrays as they are |
-| `steps` | The step log, one entry per visited node: `at`, `node_id`, `type`, `label`, `message` |
+| `steps` | The step log, one entry per visited node: `at`, `node_id`, `type`, `label`, `message`, `status` (`ok`, `retry` or `failed`), `duration_ms`, and `output` when the action produced one |
 | `error` | The exception message when the run failed |
 | `pending_resumes` | How many delayed resumes are still due |
 | `started_at`, `finished_at` | Timestamps; the Runs table shows the duration between them |
 
-Step messages are, in order of appearance: "Triggered", "Condition met, following the "true" branch" / "Condition not met, following the "false" branch", "Done" after an action, "Waiting *n* seconds before continuing" at a Wait, "Nothing to run after the wait; finished", and "Resumed after waiting" when a delayed job picks the run back up.
+Step messages are, in order of appearance: "Triggered", "Condition met, following the "true" branch" / "Condition not met, following the "false" branch", "Done" after an action, "Waiting *n* seconds before continuing" at a Wait, "Nothing to run after the wait; finished", and "Resumed after waiting" when a delayed job picks the run back up. A retried action logs "Attempt *n* of *m* failed (…), retrying"; an action set to continue on error logs "Failed (…), continuing as configured"; the step that fails a run carries the error message.
 
-The **Details** action on a run opens a modal with the status, trigger, start time, duration, the error (if any), the numbered steps with their time, and the payload summary.
+The **Details** action on a run opens a modal with the status, trigger, record, start time, duration, the error (if any), the numbered steps with their time, duration and output, and the payload summary. **Run again** on a finished run starts the workflow once more from the same trigger with the same payload — records are fetched fresh by key — so a failed HTTP call or email can be repeated after the cause is fixed.
 
 ![A run's details modal](https://raw.githubusercontent.com/packstub/filament-flow/main/docs/images/run-detail.png)
 
@@ -89,7 +90,17 @@ Event::listen(WorkflowFailed::class, function (WorkflowFailed $event): void {
 
 ## Failures
 
-When a node throws, the run is marked Failed with the exception message and `finished_at`, the exception is passed to Laravel's `report()` — so it reaches your log and error tracker as usual — and `WorkflowFailed` is dispatched. The exception is not rethrown: the request, model event or job that triggered the workflow carries on. Other branches of the same run that had not been visited yet do not run.
+When a node throws, the run is marked Failed with the exception message and `finished_at`, the exception is passed to Laravel's `report()` — so it reaches your log and error tracker as usual — and `WorkflowFailed` is dispatched. The exception is not rethrown: the request, model event or job that triggered the workflow carries on. Branches leaving the same node run one after another in the order their edges were drawn, so the branches after the failing one do not run, and side effects of the ones before it stand. A resume job for a run that another branch has since failed does nothing.
+
+Every action node has an **Error handling** section in its settings:
+
+| Setting | |
+| --- | --- |
+| Retries | How many extra attempts to make when the action throws (0–10) |
+| Seconds between retries | A pause between attempts |
+| After the last failure | **Fail the run** (default) or **Log it and continue** — the failure is reported and logged as a step, and the branch carries on |
+
+Retries repeat the whole action, so use them for actions that are safe to repeat (an HTTP call to an idempotent endpoint, a notification) rather than ones that are not.
 
 Typical failure messages:
 
@@ -106,7 +117,8 @@ Typical failure messages:
 
 ## Safety guards
 
-- **Cycle guard** — the runner remembers the path from the trigger to the current node; reaching a node that is already on that path fails the run instead of looping. A node reachable through two separate branches (a diamond) is allowed and runs once per branch.
+- **Cycle guard** — the runner remembers the path from the trigger to the current node; reaching a node that is already on that path fails the run instead of looping. A node reachable through two separate branches (a diamond) runs once, for the first branch that reaches it.
+- **Definition checks** — an active workflow cannot be saved without a trigger, with nodes that nothing leads to, or with a required setting left empty (see [Building workflows](building-workflows.md#saving)).
 - **Maximum steps** — a run stops after visiting more than `max_steps` nodes (1000 by default). Set it in the config.
 - **Registered nodes only** — a definition can only instantiate classes registered with the plugin; anything else fails the run with "is not registered".
 - **Call depth** — nested **Call workflow** actions stop at 10 levels.

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -39,8 +39,9 @@ Runs on a cron expression. `packstub-flow:cron` — registered with Laravel's sc
 | Setting | |
 | --- | --- |
 | Cron expression | Five fields: minute, hour, day of month, month, day of week. Validated when you apply the settings. `0 9 * * 1-5` is weekdays at 09:00 |
+| Timezone | The timezone the expression is evaluated in; empty means the application timezone (`app.timezone`) |
 
-The expression is evaluated in the application timezone (`app.timezone`). A node with an invalid expression never matches.
+A node with an invalid expression never matches.
 
 | Payload | |
 | --- | --- |
@@ -57,11 +58,14 @@ POST {app url}/flow/webhooks/{workflow id}/{token}
 | Setting | |
 | --- | --- |
 | Secret token | Generated for you (40 random characters); 16–120 letters, digits, dashes and underscores. The settings panel shows the full URL prefix |
+| Signing secret | Optional. When set, every request must carry an HMAC-SHA256 signature (hex, with or without a `sha256=` prefix) of the raw body, computed with this secret |
+| Signature header | The header that carries the signature; `X-Signature` by default |
 
 The endpoint:
 
 - answers `202 Accepted` with `{"accepted": true, "run": "<run id>", "status": "success"}` — with queued runs (see [Queue & scheduling](queue-and-scheduling.md)) `run` is `null` and `status` is `"queued"`;
 - answers `404` when the workflow does not exist, is inactive, or the token does not match any webhook node of that workflow (tokens are compared in constant time);
+- answers `401` when the node has a signing secret and the signature is missing or wrong;
 - reads a JSON body when the request is JSON, and form fields otherwise.
 
 ```bash
@@ -73,13 +77,13 @@ curl -X POST https://example.com/flow/webhooks/9d2f4a1e-.../your-secret-token \
 | Payload | |
 | --- | --- |
 | `webhook` | The request body: `{{ webhook.order.status }}` |
-| `headers` | Request headers, first value each, lower-cased names: `{{ headers.x-signature }}` |
+| `headers` | Request headers, first value each, lower-cased names: `{{ headers.x-request-id }}`. Credential headers (`Authorization`, `Cookie`, `X-Api-Key`, the signature header, …) are dropped before the payload is stored — the list is `webhooks.redacted_headers` in the config |
 | `webhook_token` | The token from the URL (used for matching) |
 
 The route is named `packstub-flow.webhook`, runs under the `api` and `throttle:60,1` middleware by default, and can be disabled or moved to another prefix in the config — see [Configuration](configuration.md#webhooks).
 
 > [!NOTE]
-> The token is the only authentication. Treat the URL as a secret, keep the throttle middleware, and validate anything you act on inside the workflow (a **Compare values** condition on `{{ headers.x-signature }}` or a body field is a good first step).
+> Treat the URL as a secret and keep the throttle middleware. When the sender can sign requests (most services can), set a signing secret so a leaked URL is not enough to start the workflow.
 
 ## Record created / updated / deleted
 
@@ -97,8 +101,10 @@ class Order extends Model
 | Setting | |
 | --- | --- |
 | Record type | The model class. The list contains every non-abstract model in `app/Models` that uses `HasWorkflows`, plus the classes in `models_for_triggers` (config) and `FlowPlugin::make()->models([...])` |
+| Run once per record | Skips a record the workflow has already run for (any status). Welcome series, surveys and reminders should not fire twice |
+| Only when these attributes change | **Record updated** only: attribute names; the trigger fires only when at least one of them is in `changes`. Empty fires on every update |
 
-A node matches when the payload's model is an instance of the chosen class (subclasses included).
+A node matches when the payload's model is an instance of the chosen class (subclasses included). "Status becomes *paid*" is **Record updated** watching `status`, followed by a **Record attribute** condition `status = paid`; `{{ original.status }}` still holds the previous value. Runs remember the record they started for (`subject_type` / `subject_id`), which the Runs tab shows and searches.
 
 | Payload | Provided by |
 | --- | --- |
@@ -108,6 +114,8 @@ A node matches when the payload's model is an instance of the chosen class (subc
 
 Some details worth knowing:
 
+- Mass updates (`Order::query()->update()`), `saveQuietly()` / `updateQuietly()` and soft-delete restores fire no `created` / `updated` / `deleted` event and therefore no trigger; a soft delete fires **Record deleted**.
+- A trigger fired inside a database transaction starts the run right away in sync mode; with the queue enabled the job is dispatched after the transaction commits.
 - Saves made with `saveQuietly()` / `updateQuietly()` fire no Eloquent events and therefore no trigger. The **Update record** action saves quietly by default for exactly this reason: a workflow that updates the record that started it would otherwise start itself again.
 - A model listed in the config or the plugin without the trait appears in the select but never fires on its own — dispatch the trigger yourself, or add the trait.
 - A **Record deleted** run that continues through the queue (after a **Wait**) gets the deleted record rebuilt from the attributes it had, so placeholders keep working.

--- a/resources/lang/en/flow.php
+++ b/resources/lang/en/flow.php
@@ -41,6 +41,10 @@ return [
         'close' => 'Close',
         'context' => 'Payload',
         'no_steps' => 'No steps were recorded.',
+        'output' => 'Output',
+        'subject' => 'Record',
+        'rerun' => 'Run again',
+        'rerun_description' => 'Starts the workflow again with the same records and payload. Actions such as emails and HTTP requests will run again.',
         'status' => [
             'running' => 'Running',
             'delayed' => 'Waiting',
@@ -57,6 +61,14 @@ return [
         'delayed' => 'Waiting :seconds seconds before continuing',
         'delay_skipped' => 'Nothing to run after the wait; finished',
         'resumed' => 'Resumed after waiting',
+        'retrying' => 'Attempt :attempt of :max failed (:error), retrying',
+        'continued' => 'Failed (:error), continuing as configured',
+    ],
+    'validation' => [
+        'unknown_node' => 'Node ":node" uses a trigger, action or condition that is not registered.',
+        'no_trigger' => 'Add at least one trigger before activating the workflow.',
+        'unconnected' => 'Node ":node" is not connected to anything before it.',
+        'missing_setting' => 'Node ":node": the setting ":setting" is required.',
     ],
 
     'node_settings' => [
@@ -69,6 +81,13 @@ return [
         'placeholders' => 'Placeholders',
         'placeholders_hint' => 'Text fields accept {{ placeholders }} that are filled in when the workflow runs.',
         'placeholders_intro' => 'Any value from the run payload can be referenced by its path:',
+        'error_handling' => 'Error handling',
+        'error_handling_help' => 'What happens when this action throws.',
+        'retries' => 'Retries',
+        'retry_after' => 'Seconds between retries',
+        'on_error' => 'After the last failure',
+        'on_error_fail' => 'Fail the run',
+        'on_error_continue' => 'Log it and continue',
     ],
 
     'placeholders' => [
@@ -79,6 +98,11 @@ return [
         'webhook' => 'A value from the webhook request body',
         'event' => 'A public property of the event that fired',
         'user' => 'The user who registered',
+        'last' => 'The output of the previous action (an HTTP response, for example)',
+        'outputs' => 'The output of a specific earlier action, by node id',
+        'filters' => 'Filters: date:<format>, upper, lower, title, trim, truncate:<n>, number:<decimals>, default:<value>, json, count, join:<glue>',
+        'http_status' => 'The HTTP status code of the response',
+        'http_body' => 'A value from the JSON response body',
     ],
 
     'builder' => [
@@ -116,16 +140,23 @@ return [
             'expression' => 'Cron expression',
             'expression_help' => 'Minute, hour, day of month, month, day of week — e.g. "0 9 * * 1-5" for weekdays at 09:00.',
             'invalid' => 'This is not a valid cron expression.',
+            'timezone' => 'Timezone',
+            'timezone_help' => 'The expression is evaluated in this timezone. Defaults to :default.',
         ],
         'webhook' => [
             'name' => 'Webhook',
             'description' => 'Starts when a POST request hits the webhook URL.',
             'token' => 'Secret token',
             'token_help' => 'Send a POST to :prefix/{workflow id}/{token}. The JSON body is available as {{ webhook.* }}.',
+            'signing_secret' => 'Signing secret',
+            'signing_secret_help' => 'Optional. When set, requests must carry an HMAC-SHA256 hex signature of the raw body in the signature header.',
+            'signature_header' => 'Signature header',
         ],
         'record' => [
             'model' => 'Record type',
             'model_help' => 'Models that use the HasWorkflows trait, plus the ones listed in the config.',
+            'once' => 'Run once per record',
+            'once_help' => 'Skip records this workflow has already run for (welcome series, surveys, reminders).',
         ],
         'record_created' => [
             'name' => 'Record created',
@@ -134,6 +165,8 @@ return [
         'record_updated' => [
             'name' => 'Record updated',
             'description' => 'Fires when a record of the chosen type is updated.',
+            'watch' => 'Only when these attributes change',
+            'watch_help' => 'Leave empty to fire on every update. Type an attribute name and press Enter, e.g. "status".',
         ],
         'record_deleted' => [
             'name' => 'Record deleted',
@@ -194,6 +227,10 @@ return [
             'invalid_json' => 'The body must be valid JSON.',
             'throw_on_error' => 'Fail the run on a 4xx / 5xx response',
             'throw_on_error_help' => 'Turn off to continue regardless of the response.',
+            'timeout' => 'Timeout (seconds)',
+            'timeout_help' => 'Leave empty for the default of :default seconds.',
+            'retries' => 'Retries on connection errors',
+            'retries_help' => 'Extra attempts when the request cannot be sent or times out.',
         ],
         'update_record' => [
             'name' => 'Update record',
@@ -203,6 +240,8 @@ return [
             'value' => 'Value',
             'silently' => 'Save without firing events',
             'silently_help' => 'Keeps a "record updated" trigger from starting this workflow again.',
+            'force' => 'Bypass mass-assignment protection',
+            'force_help' => 'Write attributes that are not in the model\'s $fillable list. Leave off unless you trust everyone who can edit workflows.',
         ],
         'wait' => [
             'name' => 'Wait',
@@ -210,6 +249,12 @@ return [
             'duration' => 'Duration',
             'unit' => 'Unit',
             'units' => ['seconds' => 'Seconds', 'minutes' => 'Minutes', 'hours' => 'Hours', 'days' => 'Days'],
+            'mode' => 'Wait',
+            'modes' => ['duration' => 'For a duration', 'until' => 'Until a date from the payload'],
+            'until' => 'Date',
+            'until_help' => 'A placeholder or a date, e.g. {{ model.starts_at }}. The duration above is the offset before or after it. Dates already in the past continue immediately.',
+            'direction' => 'Offset',
+            'directions' => ['before' => 'Before the date', 'after' => 'After the date'],
         ],
         'call_workflow' => [
             'name' => 'Call workflow',

--- a/resources/views/runs/detail.blade.php
+++ b/resources/views/runs/detail.blade.php
@@ -1,6 +1,10 @@
 @php
     $steps = $run->steps ?? [];
     $context = $run->context ?? [];
+    $stepColors = [
+        'failed' => 'bg-danger-100 text-danger-700 dark:bg-danger-500/20 dark:text-danger-300',
+        'retry' => 'bg-warning-100 text-warning-700 dark:bg-warning-500/20 dark:text-warning-300',
+    ];
 @endphp
 <div class="fi-flow-run-detail space-y-6 text-sm">
     <dl class="grid grid-cols-2 gap-x-6 gap-y-2 md:grid-cols-4">
@@ -20,6 +24,12 @@
             <dt class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('packstub-flow::flow.runs.duration') }}</dt>
             <dd class="mt-1 text-gray-950 dark:text-white">{{ $run->getDurationInSeconds() !== null ? $run->getDurationInSeconds().' s' : '—' }}</dd>
         </div>
+        @if ($run->subject_type)
+            <div class="col-span-2">
+                <dt class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('packstub-flow::flow.runs.subject') }}</dt>
+                <dd class="mt-1 text-gray-950 dark:text-white">{{ class_basename($run->subject_type) }} #{{ $run->subject_id }}</dd>
+            </div>
+        @endif
     </dl>
 
     @if ($run->error)
@@ -32,14 +42,24 @@
         <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('packstub-flow::flow.runs.steps') }}</h3>
         <ol class="divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-white/10 dark:border-white/10">
             @forelse ($steps as $index => $step)
+                @php $status = $step['status'] ?? 'ok'; @endphp
                 <li class="flex items-start gap-3 px-3 py-2">
-                    <span class="mt-0.5 inline-flex h-5 w-5 flex-none items-center justify-center rounded-full bg-gray-100 text-[11px] font-semibold text-gray-600 dark:bg-white/10 dark:text-gray-300">{{ $index + 1 }}</span>
+                    <span class="mt-0.5 inline-flex h-5 w-5 flex-none items-center justify-center rounded-full text-[11px] font-semibold {{ $stepColors[$status] ?? 'bg-gray-100 text-gray-600 dark:bg-white/10 dark:text-gray-300' }}">{{ $index + 1 }}</span>
                     <div class="min-w-0 flex-1">
                         <div class="flex flex-wrap items-baseline gap-x-2">
                             <span class="font-medium text-gray-950 dark:text-white">{{ $step['label'] ?? $step['node_id'] ?? '' }}</span>
                             <span class="text-xs text-gray-500 dark:text-gray-400">{{ $step['type'] ?? '' }}</span>
+                            @if (isset($step['duration_ms']))
+                                <span class="text-xs text-gray-400 dark:text-gray-500">{{ $step['duration_ms'] }} ms</span>
+                            @endif
                         </div>
-                        <div class="text-gray-600 dark:text-gray-400">{{ $step['message'] ?? '' }}</div>
+                        <div class="{{ $status === 'failed' ? 'text-danger-600 dark:text-danger-400' : 'text-gray-600 dark:text-gray-400' }}">{{ $step['message'] ?? '' }}</div>
+                        @if (! empty($step['output']))
+                            <details class="mt-1">
+                                <summary class="cursor-pointer text-xs text-gray-500 dark:text-gray-400">{{ __('packstub-flow::flow.runs.output') }}</summary>
+                                <pre class="mt-1 max-h-48 overflow-auto rounded-lg bg-gray-950 p-2 font-mono text-xs text-gray-100 dark:bg-black/40">{{ json_encode($step['output'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+                            </details>
+                        @endif
                     </div>
                     <time class="flex-none text-xs text-gray-500 dark:text-gray-400">{{ isset($step['at']) ? \Illuminate\Support\Carbon::parse($step['at'])->format('H:i:s') : '' }}</time>
                 </li>

--- a/src/Engine/Dispatcher.php
+++ b/src/Engine/Dispatcher.php
@@ -3,6 +3,8 @@
 namespace Packstub\Flow\Engine;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 use Packstub\Flow\Enums\NodeType;
 use Packstub\Flow\Flow;
 use Packstub\Flow\Jobs\RunWorkflowJob;
@@ -12,9 +14,20 @@ use Packstub\Flow\Models\WorkflowTrigger;
 use Packstub\Flow\NodeRegistry;
 use Packstub\Flow\Nodes\Trigger;
 use Packstub\Flow\Support\PayloadSerializer;
+use Throwable;
 
 class Dispatcher
 {
+    public const CACHE_KEY = 'packstub-flow.trigger-types';
+
+    /** Seconds a process keeps its copy of the active trigger types before re-reading the cache. */
+    public const REFRESH_AFTER = 60;
+
+    /** @var array<string, true>|null */
+    protected static ?array $activeTypes = null;
+
+    protected static int $loadedAt = 0;
+
     public function __construct(protected NodeRegistry $registry) {}
 
     /**
@@ -26,7 +39,7 @@ class Dispatcher
     {
         $trigger = $this->registry->trigger($triggerClass);
 
-        if (! $trigger) {
+        if (! $trigger || ! static::hasActiveTriggers($triggerClass)) {
             return [];
         }
 
@@ -43,6 +56,10 @@ class Dispatcher
 
         foreach ($rows as $row) {
             if (! $trigger->matches($row->config ?? [], $payload)) {
+                continue;
+            }
+
+            if (($row->config['once'] ?? false) && $this->alreadyRanFor($row->workflow, $payload)) {
                 continue;
             }
 
@@ -90,6 +107,65 @@ class Dispatcher
         }
 
         return (new Runner($workflow, $payload))->start($startNodeId);
+    }
+
+    /**
+     * Forget the cached list of trigger types that have an active workflow.
+     * Called whenever a workflow is saved or deleted.
+     */
+    public static function flushCache(): void
+    {
+        static::$activeTypes = null;
+        Cache::forget(self::CACHE_KEY);
+    }
+
+    /**
+     * Whether any active workflow has a trigger of this type. Model events
+     * fire on every save, so this check is a cached hash lookup rather than
+     * a query.
+     */
+    protected static function hasActiveTriggers(string $triggerClass): bool
+    {
+        if (static::$activeTypes === null || time() - static::$loadedAt >= self::REFRESH_AFTER) {
+            try {
+                $types = Cache::remember(self::CACHE_KEY, now()->addHour(), function (): array {
+                    return Flow::triggerModel()::query()
+                        ->whereHas('workflow', fn ($query) => $query->where('is_active', true))
+                        ->distinct()
+                        ->pluck('type')
+                        ->all();
+                });
+            } catch (Throwable) {
+                // Tables not migrated yet: nothing can match.
+                return false;
+            }
+
+            static::$activeTypes = array_fill_keys($types, true);
+            static::$loadedAt = time();
+        }
+
+        return isset(static::$activeTypes[$triggerClass]);
+    }
+
+    /**
+     * "Run once per record": a run already exists for this workflow and the
+     * record in the payload.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    protected function alreadyRanFor(Workflow $workflow, array $payload): bool
+    {
+        $model = $payload['model'] ?? null;
+
+        if (! $model instanceof Model || $model->getKey() === null) {
+            return false;
+        }
+
+        return Flow::runModel()::query()
+            ->where('workflow_id', $workflow->getKey())
+            ->where('subject_type', $model::class)
+            ->where('subject_id', (string) $model->getKey())
+            ->exists();
     }
 
     protected function defaultStartNode(Workflow $workflow): ?string

--- a/src/Engine/Runner.php
+++ b/src/Engine/Runner.php
@@ -2,6 +2,7 @@
 
 namespace Packstub\Flow\Engine;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;
 use Packstub\Flow\Contracts\Delayable;
 use Packstub\Flow\Enums\NodeType;
@@ -15,16 +16,28 @@ use Packstub\Flow\Jobs\ResumeWorkflowJob;
 use Packstub\Flow\Models\Workflow;
 use Packstub\Flow\Models\WorkflowRun;
 use Packstub\Flow\NodeRegistry;
+use Packstub\Flow\Nodes\Action;
 use Packstub\Flow\Support\PayloadSerializer;
 use Throwable;
 
 /**
  * Walks a workflow graph from a start node, recording every step on a
  * WorkflowRun. Conditions branch on their true/false handles, Delayable
- * actions hand the remainder of the branch to the queue.
+ * actions hand the remainder of the branch to the queue, and an action's
+ * output travels down its branch as {{ last.* }} / {{ outputs.<id>.* }}.
+ *
+ * Branches leaving the same node run one after another, in edge order. A
+ * node reached again through another branch (a join) runs once.
  */
 class Runner
 {
+    /** Node config keys reserved for the runner (see ManageNode's "Error handling" section). */
+    public const RETRIES = '_retries';
+
+    public const RETRY_AFTER = '_retry_after';
+
+    public const ON_ERROR = '_on_error';
+
     protected Graph $graph;
 
     protected NodeRegistry $registry;
@@ -34,6 +47,9 @@ class Runner
     protected int $steps = 0;
 
     protected bool $paused = false;
+
+    /** @var array<string, true> */
+    protected array $visited = [];
 
     /**
      * @param  array<string, mixed>  $payload
@@ -53,9 +69,13 @@ class Runner
 
         $runModel = Flow::runModel();
 
+        $subject = $this->payload['model'] ?? null;
+
         $this->run = $runModel::query()->create([
             'workflow_id' => $this->workflow->getKey(),
             'trigger_type' => $startNode['data']['identifier'] ?? null,
+            'subject_type' => $subject instanceof Model ? $subject::class : null,
+            'subject_id' => $subject instanceof Model ? $subject->getKey() : null,
             'status' => RunStatus::Running,
             'context' => PayloadSerializer::summarize($this->payload),
             'steps' => [],
@@ -69,7 +89,7 @@ class Runner
                 throw new WorkflowException("Start node [{$startNodeId}] not found in workflow.");
             }
 
-            $this->visit($startNode, []);
+            $this->visit($startNode, [], $this->payload);
         });
 
         return $this->run;
@@ -85,6 +105,13 @@ class Runner
         $this->run = $run;
         $this->run->decrement('pending_resumes');
         $this->run->refresh();
+
+        // Another branch failed the run while this one was waiting: leave the
+        // failure as it is instead of running the rest and reporting success.
+        if ($this->run->status === RunStatus::Failed) {
+            return $this->run;
+        }
+
         $this->run->status = RunStatus::Running;
 
         $this->execute(function () use ($nodeIds): void {
@@ -96,7 +123,7 @@ class Runner
                 }
 
                 $this->record($node, __('packstub-flow::flow.steps.resumed'));
-                $this->visit($node, []);
+                $this->visit($node, [], $this->payload);
             }
         });
 
@@ -118,6 +145,8 @@ class Runner
     {
         try {
             $callback();
+
+            $this->run->refresh();
 
             $this->finish($this->paused || $this->run->pending_resumes > 0 ? RunStatus::Delayed : RunStatus::Success);
         } catch (Throwable $exception) {
@@ -151,8 +180,9 @@ class Runner
     /**
      * @param  array<string, mixed>  $node
      * @param  array<int, string>  $path  ids of the nodes above this one on the current branch
+     * @param  array<string, mixed>  $payload  the payload as seen by this branch (trigger data plus earlier outputs)
      */
-    protected function visit(array $node, array $path): void
+    protected function visit(array $node, array $path, array $payload): void
     {
         $id = (string) $node['id'];
 
@@ -160,35 +190,51 @@ class Runner
             throw new WorkflowException("Cycle detected at node [{$id}] ({$this->label($node)}).");
         }
 
+        if (isset($this->visited[$id])) {
+            // A join: two branches lead here. It already ran for the first one.
+            return;
+        }
+
         if (++$this->steps > (int) config('packstub-flow.max_steps', 1000)) {
             throw new WorkflowException('Workflow exceeded the maximum number of steps.');
         }
 
+        $this->visited[$id] = true;
         $path[] = $id;
         $type = $node['type'] ?? null;
+        $startedAt = microtime(true);
 
-        $next = match ($type) {
-            NodeType::Trigger->value => $this->visitTrigger($node),
-            NodeType::Condition->value => $this->visitCondition($node),
-            NodeType::Action->value => $this->visitAction($node),
-            default => throw new WorkflowException("Unknown node type [{$type}] at node [{$id}]."),
-        };
+        try {
+            [$next, $payload] = match ($type) {
+                NodeType::Trigger->value => [$this->visitTrigger($node, $startedAt), $payload],
+                NodeType::Condition->value => [$this->visitCondition($node, $payload, $startedAt), $payload],
+                NodeType::Action->value => $this->visitAction($node, $payload, $startedAt),
+                default => throw new WorkflowException("Unknown node type [{$type}] at node [{$id}]."),
+            };
+        } catch (Throwable $exception) {
+            $this->record($node, $exception->getMessage(), 'failed', $startedAt);
+
+            throw $exception;
+        }
 
         foreach ($next as $child) {
-            $this->visit($child, $path);
+            $this->visit($child, $path, $payload);
         }
     }
 
     /** @return array<int, array<string, mixed>> */
-    protected function visitTrigger(array $node): array
+    protected function visitTrigger(array $node, float $startedAt): array
     {
-        $this->record($node, __('packstub-flow::flow.steps.triggered'));
+        $this->record($node, __('packstub-flow::flow.steps.triggered'), startedAt: $startedAt);
 
         return $this->graph->next($node['id']);
     }
 
-    /** @return array<int, array<string, mixed>> */
-    protected function visitCondition(array $node): array
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, array<string, mixed>>
+     */
+    protected function visitCondition(array $node, array $payload, float $startedAt): array
     {
         $identifier = $node['data']['identifier'] ?? null;
         $condition = $identifier ? $this->registry->condition($identifier) : null;
@@ -197,15 +243,18 @@ class Runner
             throw new WorkflowException("Condition [{$identifier}] is not registered.");
         }
 
-        $result = $condition->evaluate($node['data']['config'] ?? [], $this->payload);
+        $result = $condition->evaluate($node['data']['config'] ?? [], $payload);
 
-        $this->record($node, __($result ? 'packstub-flow::flow.steps.condition_true' : 'packstub-flow::flow.steps.condition_false'));
+        $this->record($node, __($result ? 'packstub-flow::flow.steps.condition_true' : 'packstub-flow::flow.steps.condition_false'), startedAt: $startedAt);
 
         return $this->graph->next($node['id'], $result ? 'true' : 'false');
     }
 
-    /** @return array<int, array<string, mixed>> */
-    protected function visitAction(array $node): array
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{0: array<int, array<string, mixed>>, 1: array<string, mixed>}
+     */
+    protected function visitAction(array $node, array $payload, float $startedAt): array
     {
         $identifier = $node['data']['identifier'] ?? null;
         $action = $identifier ? $this->registry->action($identifier) : null;
@@ -217,27 +266,80 @@ class Runner
         $config = $node['data']['config'] ?? [];
 
         if ($action instanceof Delayable) {
-            $seconds = $action->getDelaySeconds($config, $this->payload);
+            $seconds = $action->getDelaySeconds($config, $payload);
 
             if ($seconds !== null && $seconds > 0) {
-                return $this->pause($node, $seconds);
+                return [$this->pause($node, $seconds, $payload), $payload];
             }
         }
 
-        $action->handle($config, $this->payload);
+        $this->handleWithRetries($node, $action, $config, $payload);
 
-        $this->record($node, __('packstub-flow::flow.steps.action_done'));
+        $output = $action->pullOutput();
 
-        return $this->graph->next($node['id']);
+        if ($output !== null) {
+            $payload['outputs'][(string) $node['id']] = $output;
+            $payload['last'] = $output;
+        }
+
+        $this->record($node, __('packstub-flow::flow.steps.action_done'), startedAt: $startedAt, output: $output);
+
+        return [$this->graph->next($node['id']), $payload];
+    }
+
+    /**
+     * Run an action, retrying it the number of times set on the node. When the
+     * node is set to continue on error the failure is logged as a step and the
+     * branch goes on; otherwise the exception fails the run.
+     *
+     * @param  array<string, mixed>  $node
+     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>  $payload
+     */
+    protected function handleWithRetries(array $node, Action $action, array $config, array $payload): void
+    {
+        $retries = max(0, min((int) ($config[self::RETRIES] ?? 0), 10));
+        $retryAfter = max(0, (int) ($config[self::RETRY_AFTER] ?? 0));
+        $onError = (string) ($config[self::ON_ERROR] ?? 'fail');
+
+        $config = array_diff_key($config, array_flip([self::RETRIES, self::RETRY_AFTER, self::ON_ERROR]));
+
+        for ($attempt = 1; ; $attempt++) {
+            try {
+                $action->handle($config, $payload);
+
+                return;
+            } catch (Throwable $exception) {
+                if ($attempt <= $retries) {
+                    $this->record($node, __('packstub-flow::flow.steps.retrying', ['attempt' => $attempt, 'max' => $retries, 'error' => $exception->getMessage()]), 'retry');
+
+                    if ($retryAfter > 0) {
+                        sleep($retryAfter);
+                    }
+
+                    continue;
+                }
+
+                if ($onError === 'continue') {
+                    report($exception);
+                    $this->record($node, __('packstub-flow::flow.steps.continued', ['error' => $exception->getMessage()]), 'failed');
+
+                    return;
+                }
+
+                throw $exception;
+            }
+        }
     }
 
     /**
      * Schedule the nodes after a Delayable action and stop this branch.
      *
      * @param  array<string, mixed>  $node
+     * @param  array<string, mixed>  $payload
      * @return array<int, array<string, mixed>>
      */
-    protected function pause(array $node, int $seconds): array
+    protected function pause(array $node, int $seconds, array $payload): array
     {
         $nextIds = $this->graph->nextIds($node['id']);
 
@@ -254,7 +356,7 @@ class Runner
 
         $job = new ResumeWorkflowJob(
             $this->run->getKey(),
-            PayloadSerializer::serialize($this->payload),
+            PayloadSerializer::serialize($payload),
             $nextIds,
             $this->graph->toArray(),
         );
@@ -273,22 +375,50 @@ class Runner
     }
 
     /**
+     * Append a step to the run. Steps are re-read under a lock so two
+     * resumed branches finishing at the same time do not overwrite each other.
+     *
      * @param  array<string, mixed>  $node
+     * @param  array<string, mixed>|null  $output
      */
-    protected function record(array $node, string $message): void
+    protected function record(array $node, string $message, string $status = 'ok', ?float $startedAt = null, ?array $output = null): void
     {
-        $steps = $this->run->steps ?? [];
-
-        $steps[] = [
+        $step = array_filter([
             'at' => Date::now()->toIso8601String(),
             'node_id' => (string) $node['id'],
             'type' => $node['type'] ?? null,
             'label' => $this->label($node),
             'message' => $message,
-        ];
+            'status' => $status,
+            'duration_ms' => $startedAt !== null ? (int) round((microtime(true) - $startedAt) * 1000) : null,
+            'output' => $output !== null ? $this->truncateOutput($output) : null,
+        ], fn ($value): bool => $value !== null);
 
-        $this->run->steps = $steps;
-        $this->run->save();
+        $this->run->getConnection()->transaction(function () use ($step): void {
+            $fresh = $this->run->newQuery()->lockForUpdate()->find($this->run->getKey());
+
+            $steps = $fresh?->steps ?? $this->run->steps ?? [];
+            $steps[] = $step;
+
+            $this->run->steps = $steps;
+            $this->run->save();
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $output
+     * @return array<string, mixed>
+     */
+    protected function truncateOutput(array $output): array
+    {
+        $max = (int) config('packstub-flow.max_output_bytes', 16384);
+        $encoded = json_encode($output);
+
+        if ($encoded === false || strlen($encoded) <= $max) {
+            return $output;
+        }
+
+        return ['truncated' => true, 'preview' => mb_strcut($encoded, 0, $max)];
     }
 
     /** @param array<string, mixed> $node */

--- a/src/Filament/Forms/Components/FlowBuilder.php
+++ b/src/Filament/Forms/Components/FlowBuilder.php
@@ -2,8 +2,11 @@
 
 namespace Packstub\Flow\Filament\Forms\Components;
 
+use Closure;
 use Filament\Forms\Components\Field;
+use Filament\Schemas\Components\Utilities\Get;
 use Packstub\Flow\NodeRegistry;
+use Packstub\Flow\Support\DefinitionValidator;
 
 /**
  * The canvas. State is {nodes: [...], edges: [...]} in the shape used by
@@ -15,6 +18,8 @@ class FlowBuilder extends Field
 
     protected int|string $minHeight = 600;
 
+    protected bool $validatesDefinition = true;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -22,6 +27,28 @@ class FlowBuilder extends Field
         $this->default(['nodes' => [], 'edges' => []]);
         $this->dehydrateStateUsing(fn (mixed $state): array => static::normalizeState($state));
         $this->columnSpanFull();
+        $this->rule(fn (Get $get): Closure => function (string $attribute, mixed $value, Closure $fail) use ($get): void {
+            if (! $this->validatesDefinition) {
+                return;
+            }
+
+            $active = (bool) ($get('is_active') ?? true);
+
+            foreach (DefinitionValidator::problems(static::normalizeState($value), $active) as $problem) {
+                $fail($problem);
+            }
+        });
+    }
+
+    /**
+     * Skip the structural checks (trigger present, nodes connected, required
+     * settings filled) that run before an active workflow is saved.
+     */
+    public function withoutValidation(bool $condition = true): static
+    {
+        $this->validatesDefinition = ! $condition;
+
+        return $this;
     }
 
     public function minHeight(int|string $height): static

--- a/src/Filament/Livewire/ManageNode.php
+++ b/src/Filament/Livewire/ManageNode.php
@@ -5,6 +5,7 @@ namespace Packstub\Flow\Filament\Livewire;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -15,6 +16,8 @@ use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
+use Packstub\Flow\Engine\Runner;
+use Packstub\Flow\Enums\NodeType;
 use Packstub\Flow\NodeRegistry;
 use Packstub\Flow\Nodes\Node;
 
@@ -97,6 +100,34 @@ class ManageNode extends Component implements HasActions, HasForms
             $components[] = Section::make(__('packstub-flow::flow.node_settings.settings'))
                 ->description($placeholders !== [] ? __('packstub-flow::flow.node_settings.placeholders_hint') : null)
                 ->schema($settings);
+        }
+
+        if ($node?->getType() === NodeType::Action) {
+            $components[] = Section::make(__('packstub-flow::flow.node_settings.error_handling'))
+                ->description(__('packstub-flow::flow.node_settings.error_handling_help'))
+                ->collapsed()
+                ->columns(3)
+                ->schema([
+                    TextInput::make(Runner::RETRIES)
+                        ->label(__('packstub-flow::flow.node_settings.retries'))
+                        ->numeric()
+                        ->minValue(0)
+                        ->maxValue(10)
+                        ->default(0),
+                    TextInput::make(Runner::RETRY_AFTER)
+                        ->label(__('packstub-flow::flow.node_settings.retry_after'))
+                        ->numeric()
+                        ->minValue(0)
+                        ->maxValue(300)
+                        ->default(0),
+                    Select::make(Runner::ON_ERROR)
+                        ->label(__('packstub-flow::flow.node_settings.on_error'))
+                        ->options([
+                            'fail' => __('packstub-flow::flow.node_settings.on_error_fail'),
+                            'continue' => __('packstub-flow::flow.node_settings.on_error_continue'),
+                        ])
+                        ->default('fail'),
+                ]);
         }
 
         if ($placeholders !== []) {

--- a/src/Filament/Resources/WorkflowResource.php
+++ b/src/Filament/Resources/WorkflowResource.php
@@ -22,6 +22,7 @@ use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
 use Packstub\Flow\Enums\RunStatus;
 use Packstub\Flow\Facades\Flow;
 use Packstub\Flow\Filament\Forms\Components\FlowBuilder;
@@ -66,6 +67,21 @@ class WorkflowResource extends Resource
     public static function getNavigationSort(): ?int
     {
         return static::plugin()?->getNavigationSort() ?? config('packstub-flow.navigation.sort');
+    }
+
+    public static function canAccess(): bool
+    {
+        $plugin = static::plugin();
+
+        if ($plugin && ! $plugin->isAuthorized()) {
+            return false;
+        }
+
+        if (! $plugin && ($gate = config('packstub-flow.gate')) && ! Gate::allows($gate)) {
+            return false;
+        }
+
+        return parent::canAccess();
     }
 
     public static function getRecordTitleAttribute(): ?string

--- a/src/Filament/Resources/WorkflowResource/RelationManagers/RunsRelationManager.php
+++ b/src/Filament/Resources/WorkflowResource/RelationManagers/RunsRelationManager.php
@@ -5,6 +5,7 @@ namespace Packstub\Flow\Filament\Resources\WorkflowResource\RelationManagers;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Support\Enums\Width;
 use Filament\Tables\Columns\TextColumn;
@@ -12,6 +13,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Packstub\Flow\Enums\RunStatus;
+use Packstub\Flow\Facades\Flow;
 use Packstub\Flow\Models\WorkflowRun;
 
 class RunsRelationManager extends RelationManager
@@ -35,6 +37,12 @@ class RunsRelationManager extends RelationManager
                     ->label(__('packstub-flow::flow.runs.trigger'))
                     ->formatStateUsing(fn (WorkflowRun $record): ?string => $record->triggerName())
                     ->placeholder('—'),
+                TextColumn::make('subject_id')
+                    ->label(__('packstub-flow::flow.runs.subject'))
+                    ->formatStateUsing(fn (WorkflowRun $record): string => class_basename((string) $record->subject_type).' #'.$record->subject_id)
+                    ->searchable()
+                    ->placeholder('—')
+                    ->toggleable(),
                 TextColumn::make('started_at')
                     ->label(__('packstub-flow::flow.runs.started'))
                     ->dateTime()
@@ -68,6 +76,34 @@ class RunsRelationManager extends RelationManager
                     ->modalSubmitAction(false)
                     ->modalCancelActionLabel(__('packstub-flow::flow.runs.close'))
                     ->modalContent(fn (WorkflowRun $record) => view('packstub-flow::runs.detail', ['run' => $record])),
+                Action::make('rerun')
+                    ->label(__('packstub-flow::flow.runs.rerun'))
+                    ->icon('heroicon-o-arrow-path')
+                    ->color('gray')
+                    ->requiresConfirmation()
+                    ->modalDescription(__('packstub-flow::flow.runs.rerun_description'))
+                    ->visible(fn (WorkflowRun $record): bool => $record->status->isFinished() && $record->workflow?->is_active)
+                    ->action(function (WorkflowRun $record): void {
+                        $workflow = $record->workflow;
+                        $startNode = $record->trigger_type ? $workflow->triggerNode($record->trigger_type) : null;
+
+                        $run = Flow::run($workflow, $record->rebuildPayload(), isset($startNode['id']) ? (string) $startNode['id'] : null);
+
+                        if (! $run) {
+                            Notification::make()->title(__('packstub-flow::flow.actions.run_queued'))->info()->send();
+
+                            return;
+                        }
+
+                        $notification = Notification::make()
+                            ->title(__('packstub-flow::flow.actions.run_finished', ['status' => $run->status->getLabel()]));
+
+                        $run->status === RunStatus::Failed
+                            ? $notification->danger()->body($run->error)
+                            : $notification->success();
+
+                        $notification->send();
+                    }),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/src/FlowPlugin.php
+++ b/src/FlowPlugin.php
@@ -2,9 +2,11 @@
 
 namespace Packstub\Flow;
 
+use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
 use Packstub\Flow\Filament\Resources\WorkflowResource;
 use Packstub\Flow\Support\ModelFinder;
 
@@ -37,6 +39,9 @@ class FlowPlugin implements Plugin
     protected ?int $navigationSort = null;
 
     protected bool $hasResource = true;
+
+    /** @var (Closure(): bool)|null */
+    protected ?Closure $authorize = null;
 
     public static function make(): static
     {
@@ -125,6 +130,30 @@ class FlowPlugin implements Plugin
         $this->hasResource = false;
 
         return $this;
+    }
+
+    /**
+     * Who may see and manage workflows. Runs in addition to any policy on
+     * the Workflow model and the packstub-flow.gate ability.
+     *
+     * @param  Closure(): bool  $callback
+     */
+    public function authorize(Closure $callback): static
+    {
+        $this->authorize = $callback;
+
+        return $this;
+    }
+
+    public function isAuthorized(): bool
+    {
+        if ($this->authorize !== null && ! (bool) app()->call($this->authorize)) {
+            return false;
+        }
+
+        $gate = config('packstub-flow.gate');
+
+        return ! $gate || Gate::allows($gate);
     }
 
     public function navigationGroup(?string $group): static

--- a/src/FlowServiceProvider.php
+++ b/src/FlowServiceProvider.php
@@ -85,6 +85,10 @@ class FlowServiceProvider extends PackageServiceProvider
         if (config('packstub-flow.register_schedule', true)) {
             $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
                 $schedule->command('packstub-flow:cron')->everyMinute()->withoutOverlapping();
+
+                if (config('packstub-flow.prune_runs_after_days')) {
+                    $schedule->command('packstub-flow:prune')->daily();
+                }
             });
         }
     }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -37,12 +37,18 @@ class WebhookController
             abort(404);
         }
 
+        $config = (array) ($node['data']['config'] ?? []);
+
+        if (! Webhook::verifySignature($config, (string) $request->getContent(), $request->header(Webhook::signatureHeader($config)))) {
+            abort(401, 'Invalid webhook signature.');
+        }
+
         $body = $request->isJson() ? (array) $request->json()->all() : $request->all();
 
         $run = Flow::run($model, [
             'webhook' => $body,
             'webhook_token' => $token,
-            'headers' => collect($request->headers->all())->map(fn (array $values) => $values[0] ?? null)->all(),
+            'headers' => $this->headers($request),
         ], (string) $node['id']);
 
         return response()->json([
@@ -50,5 +56,21 @@ class WebhookController
             'run' => $run?->getKey(),
             'status' => $run?->status->value ?? 'queued',
         ], 202);
+    }
+
+    /**
+     * Request headers minus the ones that carry credentials, so they never
+     * land in a run's stored payload.
+     *
+     * @return array<string, string|null>
+     */
+    protected function headers(Request $request): array
+    {
+        $redacted = array_map('strtolower', (array) config('packstub-flow.webhooks.redacted_headers', []));
+
+        return collect($request->headers->all())
+            ->reject(fn (array $values, string $name): bool => in_array(strtolower($name), $redacted, true))
+            ->map(fn (array $values) => $values[0] ?? null)
+            ->all();
     }
 }

--- a/src/Jobs/ResumeWorkflowJob.php
+++ b/src/Jobs/ResumeWorkflowJob.php
@@ -3,7 +3,7 @@
 namespace Packstub\Flow\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Packstub\Flow\Engine\Graph;
@@ -15,9 +15,13 @@ use Packstub\Flow\Support\PayloadSerializer;
  * Continues a run after a Wait step. Carries a snapshot of the graph so a
  * workflow edited during the delay does not change a run already in flight.
  */
-class ResumeWorkflowJob implements ShouldQueue
+class ResumeWorkflowJob implements ShouldQueueAfterCommit
 {
     use Dispatchable, InteractsWithQueue, Queueable;
+
+    public int $tries = 1;
+
+    public int $timeout;
 
     /**
      * @param  array<string, mixed>  $payload  already serialized with PayloadSerializer
@@ -29,7 +33,9 @@ class ResumeWorkflowJob implements ShouldQueue
         public array $payload,
         public array $nodeIds,
         public array $graph,
-    ) {}
+    ) {
+        $this->timeout = (int) config('packstub-flow.queue.timeout', 300);
+    }
 
     public function handle(): void
     {

--- a/src/Jobs/RunWorkflowJob.php
+++ b/src/Jobs/RunWorkflowJob.php
@@ -3,16 +3,26 @@
 namespace Packstub\Flow\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Packstub\Flow\Engine\Runner;
 use Packstub\Flow\Flow;
 use Packstub\Flow\Support\PayloadSerializer;
 
-class RunWorkflowJob implements ShouldQueue
+/**
+ * Runs a workflow on the queue. Dispatched after the surrounding database
+ * transaction commits, so a run never sees a record that is rolled back.
+ * A run that fails is recorded as failed, not retried: retrying would repeat
+ * the actions that already ran.
+ */
+class RunWorkflowJob implements ShouldQueueAfterCommit
 {
     use Dispatchable, InteractsWithQueue, Queueable;
+
+    public int $tries = 1;
+
+    public int $timeout;
 
     /**
      * @param  array<string, mixed>  $payload  already serialized with PayloadSerializer
@@ -21,7 +31,9 @@ class RunWorkflowJob implements ShouldQueue
         public string $workflowId,
         public array $payload,
         public string $startNodeId,
-    ) {}
+    ) {
+        $this->timeout = (int) config('packstub-flow.queue.timeout', 300);
+    }
 
     public function handle(): void
     {

--- a/src/Models/WorkflowRun.php
+++ b/src/Models/WorkflowRun.php
@@ -15,6 +15,8 @@ use Packstub\Flow\NodeRegistry;
  * @property string $id
  * @property string $workflow_id
  * @property string|null $trigger_type
+ * @property class-string<Model>|null $subject_type
+ * @property string|null $subject_id
  * @property RunStatus $status
  * @property array<string, mixed>|null $context
  * @property array<int, array<string, mixed>>|null $steps
@@ -46,6 +48,50 @@ class WorkflowRun extends Model
     public function workflow(): BelongsTo
     {
         return $this->belongsTo(Flow::workflowModel(), 'workflow_id');
+    }
+
+    /**
+     * The record that started the run, if it still exists.
+     */
+    public function subject(): ?Model
+    {
+        if (! $this->subject_type || $this->subject_id === null || ! is_a($this->subject_type, Model::class, true)) {
+            return null;
+        }
+
+        return $this->subject_type::query()->find($this->subject_id);
+    }
+
+    /**
+     * Rebuild a payload from the stored context so the run can be started
+     * again: records are re-fetched by key, everything else is kept as is.
+     *
+     * @return array<string, mixed>
+     */
+    public function rebuildPayload(): array
+    {
+        return $this->rebuild($this->context ?? []);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    protected function rebuild(array $context): array
+    {
+        $payload = [];
+
+        foreach ($context as $key => $value) {
+            if (is_array($value) && isset($value['type']) && is_string($value['type']) && array_key_exists('key', $value) && count($value) === 2 && is_a($value['type'], Model::class, true)) {
+                $payload[$key] = $value['type']::query()->find($value['key']);
+
+                continue;
+            }
+
+            $payload[$key] = is_array($value) ? $this->rebuild($value) : $value;
+        }
+
+        return $payload;
     }
 
     public function scopeFinished(Builder $query): Builder

--- a/src/Nodes/Action.php
+++ b/src/Nodes/Action.php
@@ -6,6 +6,9 @@ use Packstub\Flow\Enums\NodeType;
 
 abstract class Action extends Node
 {
+    /** @var array<string, mixed>|null */
+    protected ?array $output = null;
+
     public function getType(): NodeType
     {
         return NodeType::Action;
@@ -16,4 +19,28 @@ abstract class Action extends Node
      * @param  array<string, mixed>  $payload
      */
     abstract public function handle(array $config, array $payload): void;
+
+    /**
+     * Expose values to the nodes after this one. They are available as
+     * {{ last.key }} and {{ outputs.<node id>.key }} for the rest of the branch.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function output(array $data): void
+    {
+        $this->output = $data;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     *
+     * @internal Called by the runner after handle().
+     */
+    public function pullOutput(): ?array
+    {
+        $output = $this->output;
+        $this->output = null;
+
+        return $output;
+    }
 }

--- a/src/Nodes/Actions/HttpRequest.php
+++ b/src/Nodes/Actions/HttpRequest.php
@@ -7,11 +7,18 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Packstub\Flow\Exceptions\WorkflowException;
 use Packstub\Flow\Nodes\Action;
 use Packstub\Flow\Nodes\Concerns\InterpolatesPlaceholders;
+use Packstub\Flow\Support\Placeholders;
+use Packstub\Flow\Support\UrlGuard;
 
+/**
+ * Calls a URL. The response is exposed to the nodes after it as
+ * {{ last.status }}, {{ last.body.* }} and {{ last.headers.* }}.
+ */
 class HttpRequest extends Action
 {
     use InterpolatesPlaceholders;
@@ -57,6 +64,19 @@ class HttpRequest extends Action
                         $fail(__('packstub-flow::flow.nodes.http.invalid_json'));
                     }
                 }),
+            TextInput::make('timeout')
+                ->label(__('packstub-flow::flow.nodes.http.timeout'))
+                ->helperText(__('packstub-flow::flow.nodes.http.timeout_help', ['default' => (int) config('packstub-flow.http.timeout', 15)]))
+                ->numeric()
+                ->minValue(1)
+                ->maxValue(300),
+            TextInput::make('retries')
+                ->label(__('packstub-flow::flow.nodes.http.retries'))
+                ->helperText(__('packstub-flow::flow.nodes.http.retries_help'))
+                ->numeric()
+                ->minValue(0)
+                ->maxValue(5)
+                ->default(0),
             Toggle::make('throw_on_error')
                 ->label(__('packstub-flow::flow.nodes.http.throw_on_error'))
                 ->helperText(__('packstub-flow::flow.nodes.http.throw_on_error_help'))
@@ -64,14 +84,25 @@ class HttpRequest extends Action
         ];
     }
 
+    public function getPlaceholders(): array
+    {
+        return [
+            ...Placeholders::documentation(),
+            '{{ last.status }}' => __('packstub-flow::flow.placeholders.http_status'),
+            '{{ last.body.id }}' => __('packstub-flow::flow.placeholders.http_body'),
+        ];
+    }
+
     public function handle(array $config, array $payload): void
     {
         $method = strtoupper((string) ($config['method'] ?? 'POST'));
-        $url = $this->interpolate($config['url'] ?? '', $payload);
+        $url = $this->interpolateUrl((string) ($config['url'] ?? ''), $payload);
 
         if ($url === '') {
             throw new WorkflowException('HTTP request has no URL.');
         }
+
+        UrlGuard::assertAllowed($url);
 
         $headers = $this->interpolateArray(array_filter((array) ($config['headers'] ?? [])), $payload);
         $body = $this->decodeBody($config['body'] ?? null, $payload);
@@ -82,7 +113,16 @@ class HttpRequest extends Action
             $options['json'] = $body;
         }
 
-        $response = Http::withHeaders($headers)->send($method, $url, $options);
+        $response = $this->client($config)->withHeaders($headers)->send($method, $url, $options);
+
+        $decoded = $response->json();
+
+        $this->output([
+            'status' => $response->status(),
+            'ok' => $response->successful(),
+            'body' => $decoded ?? $response->body(),
+            'headers' => collect($response->headers())->map(fn (array $values) => $values[0] ?? null)->all(),
+        ]);
 
         if (($config['throw_on_error'] ?? true) && $response->failed()) {
             throw new WorkflowException("HTTP {$method} {$url} returned {$response->status()}.");
@@ -90,6 +130,42 @@ class HttpRequest extends Action
     }
 
     /**
+     * @param  array<string, mixed>  $config
+     */
+    protected function client(array $config): PendingRequest
+    {
+        $timeout = (int) (($config['timeout'] ?? null) ?: config('packstub-flow.http.timeout', 15));
+        $retries = (int) ($config['retries'] ?? 0);
+
+        $client = Http::timeout($timeout)->connectTimeout(min($timeout, 10));
+
+        if ($retries > 0) {
+            $client = $client->retry($retries + 1, (int) config('packstub-flow.http.retry_after_ms', 500), throw: false);
+        }
+
+        return $client;
+    }
+
+    /**
+     * Placeholder values in the URL are URL-encoded so a value containing
+     * "?" or "&" cannot change the request.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    protected function interpolateUrl(string $template, array $payload): string
+    {
+        return trim((string) preg_replace_callback(
+            Placeholders::PATTERN,
+            fn (array $matches): string => rawurlencode(Placeholders::stringify(Placeholders::resolve($matches[1], $payload, $matches[2] ?? ''))),
+            $template,
+        ));
+    }
+
+    /**
+     * Builds the JSON body without letting a placeholder value break out of
+     * its position: a placeholder inside a string stays a string (escaped),
+     * a bare placeholder becomes the raw value (number, boolean, array...).
+     *
      * @param  array<string, mixed>  $payload
      */
     protected function decodeBody(?string $raw, array $payload): mixed
@@ -98,26 +174,96 @@ class HttpRequest extends Action
             return null;
         }
 
-        $decoded = json_decode($raw, true);
+        $tokens = [];
+        $template = $this->tokenize($raw, $tokens);
+
+        $decoded = json_decode($template, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            // Placeholders that expand to unquoted values (numbers, JSON) are
-            // supported by interpolating first and decoding after.
-            $decoded = json_decode($this->interpolate($raw, $payload), true);
-
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new WorkflowException('HTTP request body is not valid JSON.');
-            }
-
-            return $decoded;
+            throw new WorkflowException('HTTP request body is not valid JSON.');
         }
 
-        return is_array($decoded) ? $this->interpolateArray($decoded, $payload) : $decoded;
+        return $this->fillTokens($decoded, $tokens, $payload);
+    }
+
+    /**
+     * Replace every placeholder with a token, quoted when it stands outside a
+     * JSON string so the template becomes parseable.
+     *
+     * @param  array<string, array{placeholder: string, bare: bool}>  $tokens
+     */
+    protected function tokenize(string $raw, array &$tokens): string
+    {
+        $result = '';
+        $inString = false;
+        $length = strlen($raw);
+        $i = 0;
+
+        while ($i < $length) {
+            $char = $raw[$i];
+
+            if ($inString && $char === '\\') {
+                $result .= substr($raw, $i, 2);
+                $i += 2;
+
+                continue;
+            }
+
+            if ($char === '"') {
+                $inString = ! $inString;
+                $result .= $char;
+                $i++;
+
+                continue;
+            }
+
+            if ($char === '{' && preg_match('/\G'.substr(Placeholders::PATTERN, 1, -1).'/', $raw, $matches, 0, $i)) {
+                $token = '__flow_ph_'.count($tokens).'__';
+                $tokens[$token] = ['placeholder' => $matches[0], 'bare' => ! $inString];
+                $result .= $inString ? $token : '"'.$token.'"';
+                $i += strlen($matches[0]);
+
+                continue;
+            }
+
+            $result .= $char;
+            $i++;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, array{placeholder: string, bare: bool}>  $tokens
+     * @param  array<string, mixed>  $payload
+     */
+    protected function fillTokens(mixed $value, array $tokens, array $payload): mixed
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                $value[$key] = $this->fillTokens($item, $tokens, $payload);
+            }
+
+            return $value;
+        }
+
+        if (! is_string($value) || $tokens === [] || ! str_contains($value, '__flow_ph_')) {
+            return $value;
+        }
+
+        if (isset($tokens[$value]) && $tokens[$value]['bare']) {
+            return Placeholders::raw($tokens[$value]['placeholder'], $payload);
+        }
+
+        return strtr($value, array_map(
+            fn (array $token): string => Placeholders::render($token['placeholder'], $payload),
+            $tokens,
+        ));
     }
 
     protected function maskPlaceholders(string $json): string
     {
         // A placeholder may stand for a bare number or a quoted string; "0" is valid in both positions.
-        return (string) preg_replace('/\{\{\s*[A-Za-z0-9_.\-]+\s*\}\}/', '0', $json);
+        return (string) preg_replace(Placeholders::PATTERN, '0', $json);
     }
 }

--- a/src/Nodes/Actions/SendSlackMessage.php
+++ b/src/Nodes/Actions/SendSlackMessage.php
@@ -7,6 +7,7 @@ use Filament\Forms\Components\TextInput;
 use Illuminate\Support\Facades\Http;
 use Packstub\Flow\Nodes\Action;
 use Packstub\Flow\Nodes\Concerns\InterpolatesPlaceholders;
+use Packstub\Flow\Support\UrlGuard;
 
 /**
  * Posts to a Slack incoming webhook.
@@ -54,6 +55,10 @@ class SendSlackMessage extends Action
             return;
         }
 
-        Http::post($url, ['text' => $this->interpolate($config['message'] ?? '', $payload)])->throw();
+        UrlGuard::assertAllowed($url);
+
+        Http::timeout((int) config('packstub-flow.http.timeout', 15))
+            ->post($url, ['text' => $this->interpolate($config['message'] ?? '', $payload)])
+            ->throw();
     }
 }

--- a/src/Nodes/Actions/UpdateRecord.php
+++ b/src/Nodes/Actions/UpdateRecord.php
@@ -4,13 +4,17 @@ namespace Packstub\Flow\Nodes\Actions;
 
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\Toggle;
+use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Database\Eloquent\Model;
 use Packstub\Flow\Exceptions\WorkflowException;
 use Packstub\Flow\Nodes\Action;
 use Packstub\Flow\Nodes\Concerns\InterpolatesPlaceholders;
+use Packstub\Flow\Support\Placeholders;
 
 /**
- * Updates the record that started the run.
+ * Updates the record that started the run. Attributes go through the
+ * model's mass-assignment rules ($fillable / $guarded) unless the node is
+ * told to bypass them.
  */
 class UpdateRecord extends Action
 {
@@ -43,6 +47,10 @@ class UpdateRecord extends Action
                 ->label(__('packstub-flow::flow.nodes.update_record.silently'))
                 ->helperText(__('packstub-flow::flow.nodes.update_record.silently_help'))
                 ->default(true),
+            Toggle::make('force')
+                ->label(__('packstub-flow::flow.nodes.update_record.force'))
+                ->helperText(__('packstub-flow::flow.nodes.update_record.force_help'))
+                ->default(false),
         ];
     }
 
@@ -54,18 +62,49 @@ class UpdateRecord extends Action
             throw new WorkflowException('Update record needs a record in the payload; use it after a record trigger.');
         }
 
-        $attributes = $this->interpolateArray(array_filter((array) ($config['attributes'] ?? []), fn ($key) => $key !== '', ARRAY_FILTER_USE_KEY), $payload);
+        $attributes = [];
+
+        foreach ((array) ($config['attributes'] ?? []) as $key => $value) {
+            if ($key === '') {
+                continue;
+            }
+
+            // A bare placeholder keeps its type (null, number, boolean, array).
+            $attributes[$key] = is_string($value) && Placeholders::isSingle($value)
+                ? Placeholders::raw($value, $payload)
+                : $this->interpolate(is_string($value) ? $value : Placeholders::stringify($value), $payload);
+        }
 
         if ($attributes === []) {
             return;
         }
 
-        $model->forceFill($attributes);
+        if ($config['force'] ?? false) {
+            $model->forceFill($attributes);
+        } else {
+            try {
+                $model->fill($attributes);
+            } catch (MassAssignmentException $exception) {
+                throw new WorkflowException("Update record: {$exception->getMessage()}. Add the attribute to \$fillable or enable \"Bypass mass-assignment protection\" on the node.");
+            }
+
+            $ignored = array_diff(array_keys($attributes), array_keys($model->getDirty()), array_keys($model->getAttributes()));
+
+            if ($ignored !== [] && $model->totallyGuarded() === false) {
+                foreach ($ignored as $attribute) {
+                    if (! $model->isFillable($attribute)) {
+                        throw new WorkflowException("Update record: [{$attribute}] is not fillable on ".$model::class.'. Add it to $fillable or enable "Bypass mass-assignment protection" on the node.');
+                    }
+                }
+            }
+        }
 
         if ($config['silently'] ?? true) {
             $model->saveQuietly();
         } else {
             $model->save();
         }
+
+        $this->output(['changes' => $model->getChanges()]);
     }
 }

--- a/src/Nodes/Actions/Wait.php
+++ b/src/Nodes/Actions/Wait.php
@@ -2,16 +2,26 @@
 
 namespace Packstub\Flow\Nodes\Actions;
 
+use Carbon\Carbon;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Utilities\Get;
+use Illuminate\Support\Facades\Date;
 use Packstub\Flow\Contracts\Delayable;
 use Packstub\Flow\Nodes\Action;
+use Packstub\Flow\Nodes\Concerns\InterpolatesPlaceholders;
+use Packstub\Flow\Support\Placeholders;
+use Throwable;
 
 /**
- * Pauses the run; the nodes after it continue through the queue.
+ * Pauses the run; the nodes after it continue through the queue. Either for
+ * a fixed duration or until a date taken from the payload, with an optional
+ * offset ("1 day before {{ model.starts_at }}").
  */
 class Wait extends Action implements Delayable
 {
+    use InterpolatesPlaceholders;
+
     public function getName(): string
     {
         return __('packstub-flow::flow.nodes.wait.name');
@@ -29,27 +39,78 @@ class Wait extends Action implements Delayable
 
     public function getFormSchema(): array
     {
+        $units = [
+            'seconds' => __('packstub-flow::flow.nodes.wait.units.seconds'),
+            'minutes' => __('packstub-flow::flow.nodes.wait.units.minutes'),
+            'hours' => __('packstub-flow::flow.nodes.wait.units.hours'),
+            'days' => __('packstub-flow::flow.nodes.wait.units.days'),
+        ];
+
         return [
+            Select::make('mode')
+                ->label(__('packstub-flow::flow.nodes.wait.mode'))
+                ->options([
+                    'duration' => __('packstub-flow::flow.nodes.wait.modes.duration'),
+                    'until' => __('packstub-flow::flow.nodes.wait.modes.until'),
+                ])
+                ->default('duration')
+                ->required()
+                ->live(),
             TextInput::make('duration')
                 ->label(__('packstub-flow::flow.nodes.wait.duration'))
                 ->numeric()
-                ->minValue(1)
+                ->minValue(0)
                 ->default(1)
                 ->required(),
             Select::make('unit')
                 ->label(__('packstub-flow::flow.nodes.wait.unit'))
-                ->options([
-                    'seconds' => __('packstub-flow::flow.nodes.wait.units.seconds'),
-                    'minutes' => __('packstub-flow::flow.nodes.wait.units.minutes'),
-                    'hours' => __('packstub-flow::flow.nodes.wait.units.hours'),
-                    'days' => __('packstub-flow::flow.nodes.wait.units.days'),
-                ])
+                ->options($units)
                 ->default('minutes')
                 ->required(),
+            TextInput::make('until')
+                ->label(__('packstub-flow::flow.nodes.wait.until'))
+                ->placeholder('{{ model.starts_at }}')
+                ->helperText(__('packstub-flow::flow.nodes.wait.until_help'))
+                ->visible(fn (Get $get): bool => $get('mode') === 'until')
+                ->required(fn (Get $get): bool => $get('mode') === 'until'),
+            Select::make('direction')
+                ->label(__('packstub-flow::flow.nodes.wait.direction'))
+                ->options([
+                    'before' => __('packstub-flow::flow.nodes.wait.directions.before'),
+                    'after' => __('packstub-flow::flow.nodes.wait.directions.after'),
+                ])
+                ->default('before')
+                ->visible(fn (Get $get): bool => $get('mode') === 'until'),
         ];
     }
 
     public function getDelaySeconds(array $config, array $payload): ?int
+    {
+        $offset = $this->durationSeconds($config);
+
+        if (($config['mode'] ?? 'duration') !== 'until') {
+            return $offset > 0 ? $offset : null;
+        }
+
+        $target = $this->targetDate($config, $payload);
+
+        if (! $target) {
+            return null;
+        }
+
+        $target = ($config['direction'] ?? 'before') === 'before'
+            ? $target->subSeconds($offset)
+            : $target->addSeconds($offset);
+
+        $seconds = (int) Date::now()->diffInSeconds($target, false);
+
+        return $seconds > 0 ? $seconds : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    protected function durationSeconds(array $config): int
     {
         $duration = (int) ($config['duration'] ?? 0);
 
@@ -60,7 +121,28 @@ class Wait extends Action implements Delayable
             default => 1,
         };
 
-        return $duration > 0 ? $duration * $multiplier : null;
+        return max(0, $duration * $multiplier);
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>  $payload
+     */
+    protected function targetDate(array $config, array $payload): ?Carbon
+    {
+        $template = (string) ($config['until'] ?? '');
+
+        $value = Placeholders::isSingle($template) ? Placeholders::raw($template, $payload) : $this->interpolate($template, $payload);
+
+        if (blank($value)) {
+            return null;
+        }
+
+        try {
+            return $value instanceof \DateTimeInterface ? Carbon::instance($value) : Carbon::parse(Placeholders::stringify($value));
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     public function handle(array $config, array $payload): void

--- a/src/Nodes/Triggers/RecordTrigger.php
+++ b/src/Nodes/Triggers/RecordTrigger.php
@@ -3,6 +3,7 @@
 namespace Packstub\Flow\Nodes\Triggers;
 
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
 use Illuminate\Database\Eloquent\Model;
 use Packstub\Flow\Nodes\Trigger;
 use Packstub\Flow\Support\ModelFinder;
@@ -18,6 +19,10 @@ abstract class RecordTrigger extends Trigger
                 ->searchable()
                 ->required()
                 ->helperText(__('packstub-flow::flow.nodes.record.model_help')),
+            Toggle::make('once')
+                ->label(__('packstub-flow::flow.nodes.record.once'))
+                ->helperText(__('packstub-flow::flow.nodes.record.once_help'))
+                ->default(false),
         ];
     }
 

--- a/src/Nodes/Triggers/RecordUpdated.php
+++ b/src/Nodes/Triggers/RecordUpdated.php
@@ -2,6 +2,12 @@
 
 namespace Packstub\Flow\Nodes\Triggers;
 
+use Filament\Forms\Components\TagsInput;
+
+/**
+ * Fires when a record is saved with changes; optionally only when one of a
+ * list of attributes changed ("when status changes").
+ */
 class RecordUpdated extends RecordTrigger
 {
     public function getName(): string
@@ -17,6 +23,34 @@ class RecordUpdated extends RecordTrigger
     public function getIcon(): ?string
     {
         return 'heroicon-o-pencil-square';
+    }
+
+    public function getFormSchema(): array
+    {
+        return [
+            ...parent::getFormSchema(),
+            TagsInput::make('watch')
+                ->label(__('packstub-flow::flow.nodes.record_updated.watch'))
+                ->placeholder('status')
+                ->helperText(__('packstub-flow::flow.nodes.record_updated.watch_help')),
+        ];
+    }
+
+    public function matches(array $config, array $payload): bool
+    {
+        if (! parent::matches($config, $payload)) {
+            return false;
+        }
+
+        $watch = array_values(array_filter(array_map('trim', (array) ($config['watch'] ?? []))));
+
+        if ($watch === []) {
+            return true;
+        }
+
+        $changed = array_keys((array) ($payload['changes'] ?? []));
+
+        return array_intersect($watch, $changed) !== [];
     }
 
     public function getPlaceholders(): array

--- a/src/Nodes/Triggers/Schedule.php
+++ b/src/Nodes/Triggers/Schedule.php
@@ -3,6 +3,7 @@
 namespace Packstub\Flow\Nodes\Triggers;
 
 use Cron\CronExpression;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Illuminate\Support\Facades\Date;
 use Packstub\Flow\Nodes\Trigger;
@@ -40,6 +41,12 @@ class Schedule extends Trigger
                         $fail(__('packstub-flow::flow.nodes.schedule.invalid'));
                     }
                 }),
+            Select::make('timezone')
+                ->label(__('packstub-flow::flow.nodes.schedule.timezone'))
+                ->helperText(__('packstub-flow::flow.nodes.schedule.timezone_help', ['default' => config('app.timezone')]))
+                ->options(fn (): array => array_combine($zones = timezone_identifiers_list(), $zones))
+                ->searchable()
+                ->placeholder(config('app.timezone')),
         ];
     }
 
@@ -51,6 +58,8 @@ class Schedule extends Trigger
             return false;
         }
 
-        return (new CronExpression($expression))->isDue($payload['now'] ?? Date::now(), config('app.timezone'));
+        $timezone = (string) ($config['timezone'] ?? '') ?: config('app.timezone');
+
+        return (new CronExpression($expression))->isDue($payload['now'] ?? Date::now(), $timezone);
     }
 }

--- a/src/Nodes/Triggers/Webhook.php
+++ b/src/Nodes/Triggers/Webhook.php
@@ -8,10 +8,13 @@ use Packstub\Flow\Nodes\Trigger;
 
 /**
  * Starts the workflow when a POST hits the webhook URL. The request JSON is
- * available to nodes as {{ webhook.* }}.
+ * available to nodes as {{ webhook.* }}. With a signing secret set, the
+ * request must carry an HMAC-SHA256 signature of the raw body.
  */
 class Webhook extends Trigger
 {
+    public const DEFAULT_SIGNATURE_HEADER = 'X-Signature';
+
     public function getName(): string
     {
         return __('packstub-flow::flow.nodes.webhook.name');
@@ -38,6 +41,16 @@ class Webhook extends Trigger
                 ->minLength(16)
                 ->maxLength(120)
                 ->alphaDash(),
+            TextInput::make('signing_secret')
+                ->label(__('packstub-flow::flow.nodes.webhook.signing_secret'))
+                ->helperText(__('packstub-flow::flow.nodes.webhook.signing_secret_help'))
+                ->password()
+                ->revealable()
+                ->maxLength(255),
+            TextInput::make('signature_header')
+                ->label(__('packstub-flow::flow.nodes.webhook.signature_header'))
+                ->placeholder(self::DEFAULT_SIGNATURE_HEADER)
+                ->maxLength(80),
         ];
     }
 
@@ -47,6 +60,37 @@ class Webhook extends Trigger
         $given = $payload['webhook_token'] ?? null;
 
         return is_string($token) && is_string($given) && hash_equals($token, $given);
+    }
+
+    /**
+     * Whether a raw request body carries a valid signature for this node.
+     * Accepts "<hex>" and "sha256=<hex>".
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public static function verifySignature(array $config, string $body, ?string $signature): bool
+    {
+        $secret = (string) ($config['signing_secret'] ?? '');
+
+        if ($secret === '') {
+            return true;
+        }
+
+        if (! is_string($signature) || $signature === '') {
+            return false;
+        }
+
+        $signature = strtolower(trim(Str::after($signature, 'sha256=')));
+
+        return hash_equals(hash_hmac('sha256', $body, $secret), $signature);
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public static function signatureHeader(array $config): string
+    {
+        return trim((string) ($config['signature_header'] ?? '')) ?: self::DEFAULT_SIGNATURE_HEADER;
     }
 
     public function getPlaceholders(): array

--- a/src/Observers/WorkflowObserver.php
+++ b/src/Observers/WorkflowObserver.php
@@ -2,6 +2,7 @@
 
 namespace Packstub\Flow\Observers;
 
+use Packstub\Flow\Engine\Dispatcher;
 use Packstub\Flow\Enums\NodeType;
 use Packstub\Flow\Listeners\DispatchEventTriggers;
 use Packstub\Flow\Models\Workflow;
@@ -12,6 +13,16 @@ use Packstub\Flow\Models\Workflow;
 class WorkflowObserver
 {
     public function saved(Workflow $workflow): void
+    {
+        $workflow->getConnection()->transaction(function () use ($workflow): void {
+            $this->syncTriggers($workflow);
+        });
+
+        DispatchEventTriggers::flush();
+        Dispatcher::flushCache();
+    }
+
+    protected function syncTriggers(Workflow $workflow): void
     {
         $workflow->triggers()->delete();
 
@@ -32,8 +43,6 @@ class WorkflowObserver
                 'config' => $node['data']['config'] ?? [],
             ]);
         }
-
-        DispatchEventTriggers::flush();
     }
 
     public function deleting(Workflow $workflow): void
@@ -47,5 +56,6 @@ class WorkflowObserver
     public function deleted(Workflow $workflow): void
     {
         DispatchEventTriggers::flush();
+        Dispatcher::flushCache();
     }
 }

--- a/src/Support/DefinitionValidator.php
+++ b/src/Support/DefinitionValidator.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Packstub\Flow\Support;
+
+use Filament\Forms\Components\Field;
+use Packstub\Flow\Engine\Graph;
+use Packstub\Flow\Enums\NodeType;
+use Packstub\Flow\NodeRegistry;
+use Throwable;
+
+/**
+ * Checks a workflow definition before it is saved: every node must be a
+ * registered class, and an active workflow needs a trigger, no dangling
+ * nodes and no empty required settings.
+ */
+class DefinitionValidator
+{
+    /**
+     * @param  array{nodes?: array<int, array<string, mixed>>, edges?: array<int, array<string, mixed>>}|null  $definition
+     * @return array<int, string> problems found, empty when the definition is fine
+     */
+    public static function problems(?array $definition, bool $active = true): array
+    {
+        $graph = Graph::fromDefinition($definition);
+        $registry = app(NodeRegistry::class);
+        $problems = [];
+
+        $nodes = $graph->nodes();
+        $triggers = $graph->nodesOfType(NodeType::Trigger->value);
+
+        foreach ($nodes as $node) {
+            $identifier = $node['data']['identifier'] ?? null;
+            $label = (string) ($node['data']['label'] ?? $node['id']);
+
+            if (! is_string($identifier) || ! $registry->has($identifier)) {
+                $problems[] = __('packstub-flow::flow.validation.unknown_node', ['node' => $label]);
+            }
+        }
+
+        if (! $active) {
+            return $problems;
+        }
+
+        if ($triggers === []) {
+            $problems[] = __('packstub-flow::flow.validation.no_trigger');
+        }
+
+        $targets = array_fill_keys(array_map(fn (array $edge): string => (string) ($edge['target'] ?? ''), $graph->edges()), true);
+
+        foreach ($nodes as $node) {
+            $label = (string) ($node['data']['label'] ?? $node['id']);
+
+            if (($node['type'] ?? null) !== NodeType::Trigger->value && ! isset($targets[(string) $node['id']])) {
+                $problems[] = __('packstub-flow::flow.validation.unconnected', ['node' => $label]);
+            }
+
+            foreach (self::missingSettings($node, $registry) as $setting) {
+                $problems[] = __('packstub-flow::flow.validation.missing_setting', ['node' => $label, 'setting' => $setting]);
+            }
+        }
+
+        return $problems;
+    }
+
+    /**
+     * Required fields of the node's settings form that are blank.
+     *
+     * @param  array<string, mixed>  $node
+     * @return array<int, string>
+     */
+    protected static function missingSettings(array $node, NodeRegistry $registry): array
+    {
+        $identifier = $node['data']['identifier'] ?? null;
+        $instance = is_string($identifier) ? $registry->node($identifier) : null;
+
+        if (! $instance) {
+            return [];
+        }
+
+        $config = (array) ($node['data']['config'] ?? []);
+        $missing = [];
+
+        foreach ($instance->getFormSchema() as $component) {
+            if (! $component instanceof Field) {
+                continue;
+            }
+
+            try {
+                // Conditionally required fields need a form context; treat
+                // any failure to evaluate as "not required".
+                $required = $component->isRequired();
+                $label = $component->getLabel();
+            } catch (Throwable) {
+                continue;
+            }
+
+            if ($required && blank($config[$component->getName()] ?? null)) {
+                $missing[] = is_string($label) ? $label : $component->getName();
+            }
+        }
+
+        return $missing;
+    }
+}

--- a/src/Support/Placeholders.php
+++ b/src/Support/Placeholders.php
@@ -4,16 +4,21 @@ namespace Packstub\Flow\Support;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Stringable;
+use Throwable;
 
 /**
  * Renders {{ path }} placeholders against a run's payload. Paths are resolved
  * with data_get(), so {{ model.name }}, {{ model.team.name }},
- * {{ webhook.order.total }} and {{ event.order.id }} all work.
+ * {{ webhook.order.total }} and {{ event.order.id }} all work. A value can be
+ * passed through filters: {{ model.created_at | date:Y-m-d }},
+ * {{ model.name | upper }}, {{ webhook.note | default:none }}.
  */
 class Placeholders
 {
-    protected const PATTERN = '/\{\{\s*([A-Za-z0-9_.\-]+)\s*\}\}/';
+    public const PATTERN = '/\{\{\s*([A-Za-z0-9_.\-]+)((?:\s*\|\s*[A-Za-z_]+(?::[^|}]*?)?)*)\s*\}\}/';
 
     /**
      * @param  array<string, mixed>  $payload
@@ -26,7 +31,7 @@ class Placeholders
 
         return (string) preg_replace_callback(
             self::PATTERN,
-            fn (array $matches): string => self::stringify(self::resolve($matches[1], $payload)),
+            fn (array $matches): string => self::stringify(self::resolve($matches[1], $payload, $matches[2] ?? '')),
             $template,
         );
     }
@@ -50,11 +55,11 @@ class Placeholders
     }
 
     /**
-     * Resolve a single placeholder path to its raw value.
+     * Resolve a single placeholder path (with optional filters) to its raw value.
      *
      * @param  array<string, mixed>  $payload
      */
-    public static function resolve(string $path, array $payload): mixed
+    public static function resolve(string $path, array $payload, string $filters = ''): mixed
     {
         // "model" is the record that fired a trigger; "record" is an alias
         // so both read naturally in a template.
@@ -62,7 +67,108 @@ class Placeholders
             $path = 'model'.substr($path, 6);
         }
 
-        return data_get($payload, $path);
+        $value = $payload;
+
+        foreach (explode('.', $path) as $segment) {
+            // Hidden attributes (passwords, tokens) never leave the model.
+            if ($value instanceof Model && in_array($segment, $value->getHidden(), true)) {
+                return null;
+            }
+
+            $value = data_get($value, $segment);
+
+            if ($value === null) {
+                break;
+            }
+        }
+
+        return self::applyFilters($value, $filters);
+    }
+
+    /**
+     * When a template is exactly one placeholder, return its raw value so
+     * numbers, booleans and arrays keep their type. Otherwise null.
+     */
+    public static function raw(string $template, array $payload): mixed
+    {
+        if (! preg_match('/^\s*'.substr(self::PATTERN, 1, -1).'\s*$/', $template, $matches)) {
+            return null;
+        }
+
+        return self::resolve($matches[1], $payload, $matches[2] ?? '');
+    }
+
+    public static function isSingle(string $template): bool
+    {
+        return (bool) preg_match('/^\s*'.substr(self::PATTERN, 1, -1).'\s*$/', $template);
+    }
+
+    protected static function applyFilters(mixed $value, string $filters): mixed
+    {
+        if (trim($filters) === '') {
+            return $value;
+        }
+
+        foreach (array_filter(array_map('trim', explode('|', $filters))) as $filter) {
+            [$name, $argument] = array_pad(explode(':', $filter, 2), 2, null);
+
+            $value = self::applyFilter($value, strtolower(trim($name)), $argument);
+        }
+
+        return $value;
+    }
+
+    protected static function applyFilter(mixed $value, string $name, ?string $argument): mixed
+    {
+        try {
+            return match ($name) {
+                'default' => blank($value) ? $argument : $value,
+                'upper' => mb_strtoupper(self::stringify($value)),
+                'lower' => mb_strtolower(self::stringify($value)),
+                'title' => Str::title(self::stringify($value)),
+                'trim' => trim(self::stringify($value)),
+                'truncate' => Str::limit(self::stringify($value), (int) ($argument ?? 100)),
+                'date' => self::formatDate($value, $argument ?? 'Y-m-d'),
+                'number' => is_numeric($n = self::loose($value)) ? number_format((float) $n, (int) ($argument ?? 0)) : self::stringify($value),
+                'json' => json_encode(self::jsonable($value), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+                'count' => match (true) {
+                    is_countable($value) => count($value),
+                    $value instanceof Arrayable => count($value->toArray()),
+                    default => blank($value) ? 0 : 1,
+                },
+                'join' => is_iterable($value) ? implode($argument ?? ', ', array_map(self::stringify(...), collect($value)->all())) : self::stringify($value),
+                'first' => is_iterable($value) ? collect($value)->first() : $value,
+                'last' => is_iterable($value) ? collect($value)->last() : $value,
+                default => $value,
+            };
+        } catch (Throwable) {
+            return $value;
+        }
+    }
+
+    protected static function formatDate(mixed $value, string $format): string
+    {
+        if (blank($value)) {
+            return '';
+        }
+
+        $date = $value instanceof \DateTimeInterface ? Carbon::instance($value) : Carbon::parse(self::stringify($value));
+
+        return $date->format($format);
+    }
+
+    protected static function loose(mixed $value): mixed
+    {
+        return $value instanceof \BackedEnum ? $value->value : $value;
+    }
+
+    protected static function jsonable(mixed $value): mixed
+    {
+        return match (true) {
+            $value instanceof Model => $value->attributesToArray(),
+            $value instanceof Arrayable => $value->toArray(),
+            default => $value,
+        };
     }
 
     public static function stringify(mixed $value): string
@@ -71,6 +177,7 @@ class Placeholders
             $value === null => '',
             is_bool($value) => $value ? '1' : '0',
             is_scalar($value) => (string) $value,
+            $value instanceof \BackedEnum => (string) $value->value,
             $value instanceof Model => (string) $value->getKey(),
             $value instanceof \DateTimeInterface => $value->format(\DateTimeInterface::ATOM),
             $value instanceof Stringable => (string) $value,
@@ -90,6 +197,9 @@ class Placeholders
             '{{ model.team.name }}' => __('packstub-flow::flow.placeholders.model_relation'),
             '{{ webhook.order.id }}' => __('packstub-flow::flow.placeholders.webhook'),
             '{{ event.order.total }}' => __('packstub-flow::flow.placeholders.event'),
+            '{{ last.body.id }}' => __('packstub-flow::flow.placeholders.last'),
+            '{{ outputs.node_id.status }}' => __('packstub-flow::flow.placeholders.outputs'),
+            '{{ model.created_at | date:Y-m-d }}' => __('packstub-flow::flow.placeholders.filters'),
         ];
     }
 

--- a/src/Support/UrlGuard.php
+++ b/src/Support/UrlGuard.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Packstub\Flow\Support;
+
+use Packstub\Flow\Exceptions\WorkflowException;
+
+/**
+ * Decides which URLs the HTTP actions may call. Workflows are edited in the
+ * panel, so without a guard anyone who can edit one could point a request at
+ * localhost, a private network or a cloud metadata endpoint.
+ */
+class UrlGuard
+{
+    /**
+     * @throws WorkflowException when the URL must not be called
+     */
+    public static function assertAllowed(string $url): void
+    {
+        $parts = parse_url($url);
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower(trim((string) ($parts['host'] ?? ''), '[]'));
+
+        if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+            throw new WorkflowException("URL [{$url}] is not an http(s) URL.");
+        }
+
+        $allowed = array_values(array_filter(array_map('strtolower', (array) config('packstub-flow.http.allowed_hosts', []))));
+
+        if ($allowed !== []) {
+            foreach ($allowed as $pattern) {
+                if (self::hostMatches($host, $pattern)) {
+                    return;
+                }
+            }
+
+            throw new WorkflowException("Host [{$host}] is not in packstub-flow.http.allowed_hosts.");
+        }
+
+        if (! config('packstub-flow.http.block_private_networks', true)) {
+            return;
+        }
+
+        foreach (self::addressesOf($host) as $ip) {
+            if (self::isPrivate($ip)) {
+                throw new WorkflowException("Host [{$host}] resolves to a private or reserved address and cannot be called.");
+            }
+        }
+    }
+
+    protected static function hostMatches(string $host, string $pattern): bool
+    {
+        if (str_starts_with($pattern, '*.')) {
+            $suffix = substr($pattern, 1);
+
+            return str_ends_with($host, $suffix) || $host === substr($pattern, 2);
+        }
+
+        return $host === $pattern;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected static function addressesOf(string $host): array
+    {
+        if ($host === 'localhost' || str_ends_with($host, '.localhost') || str_ends_with($host, '.internal')) {
+            return ['127.0.0.1'];
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return [$host];
+        }
+
+        $records = @dns_get_record($host, DNS_A | DNS_AAAA) ?: [];
+
+        return array_values(array_filter(array_map(
+            fn (array $record): ?string => $record['ip'] ?? $record['ipv6'] ?? null,
+            $records,
+        )));
+    }
+
+    public static function isPrivate(string $ip): bool
+    {
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false;
+    }
+}

--- a/tests/Feature/ActionsTest.php
+++ b/tests/Feature/ActionsTest.php
@@ -17,6 +17,7 @@ use Packstub\Flow\Nodes\Actions\UpdateRecord;
 use Packstub\Flow\Nodes\Actions\WriteLog;
 use Packstub\Flow\Nodes\Triggers\Manual;
 use Packstub\Flow\Nodes\Triggers\RecordUpdated;
+use Packstub\Flow\Tests\Fixtures\GuardedOrder;
 use Packstub\Flow\Tests\Fixtures\Order;
 use Packstub\Flow\Tests\Fixtures\SetStatusAction;
 
@@ -157,4 +158,70 @@ it('lets a custom action registered through the plugin run inside a workflow', f
 
     expect($run->status)->toBe(RunStatus::Success)
         ->and(SetStatusAction::$calls[0]['config'])->toBe(['status' => 'custom']);
+});
+
+it('builds the JSON body without letting placeholder values break out of their position', function (): void {
+    Http::fake(['api.example.com/*' => Http::response(['ok' => true])]);
+
+    $order = createOrder(['reference' => 'ORD-"x", "admin": true, "y": "', 'total' => 12.5]);
+
+    (new HttpRequest)->handle([
+        'method' => 'POST',
+        'url' => 'https://api.example.com/orders',
+        'body' => '{"ref": "{{ model.reference }}", "note": "Order {{ model.reference }}!", "total": {{ model.total }}, "raw": {{ model }}, "flag": {{ missing.flag }}}',
+    ], ['model' => $order]);
+
+    Http::assertSent(function ($request) use ($order): bool {
+        $body = $request->data();
+
+        return $body['ref'] === $order->reference
+            && $body['note'] === "Order {$order->reference}!"
+            && $body['total'] === 12.5
+            && ! array_key_exists('admin', $body)
+            && $body['raw']['reference'] === $order->reference
+            && $body['flag'] === null;
+    });
+});
+
+it('url-encodes placeholder values in the URL', function (): void {
+    Http::fake();
+
+    (new HttpRequest)->handle(['method' => 'GET', 'url' => 'https://api.example.com/search?q={{ webhook.q }}'], ['webhook' => ['q' => 'a b&c=d']]);
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.example.com/search?q=a%20b%26c%3Dd');
+});
+
+it('applies a timeout and retries to HTTP requests', function (): void {
+    Http::fake([
+        'flaky.example.com/*' => Http::sequence()->pushStatus(500)->push(['ok' => true]),
+    ]);
+
+    $action = new HttpRequest;
+    $action->handle(['method' => 'GET', 'url' => 'https://flaky.example.com/', 'retries' => 0, 'throw_on_error' => false], []);
+
+    expect($action->pullOutput())->toMatchArray(['status' => 500, 'ok' => false]);
+});
+
+it('respects mass-assignment protection unless the node bypasses it', function (): void {
+    $order = GuardedOrder::query()->create(['reference' => 'G-1']);
+
+    expect(fn () => (new UpdateRecord)->handle(['attributes' => ['status' => 'paid']], ['model' => $order]))
+        ->toThrow(WorkflowException::class, 'not fillable');
+
+    expect($order->fresh()->status)->toBe('pending');
+
+    (new UpdateRecord)->handle(['attributes' => ['status' => 'paid'], 'force' => true], ['model' => $order]);
+
+    expect($order->fresh()->status)->toBe('paid');
+});
+
+it('keeps the type of a bare placeholder when updating a record', function (): void {
+    $order = createOrder(['total' => 10]);
+
+    $action = new UpdateRecord;
+    $action->handle(['attributes' => ['total' => '{{ webhook.total }}', 'status' => 'paid-{{ webhook.id }}']], ['model' => $order, 'webhook' => ['total' => 99.5, 'id' => 7]]);
+
+    expect($order->fresh()->total)->toBe(99.5)
+        ->and($order->fresh()->status)->toBe('paid-7')
+        ->and($action->pullOutput()['changes'])->toHaveKeys(['total', 'status']);
 });

--- a/tests/Feature/AuthorizationTest.php
+++ b/tests/Feature/AuthorizationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Gate;
+use Packstub\Flow\Filament\Resources\WorkflowResource;
+use Packstub\Flow\FlowPlugin;
+
+beforeEach(function (): void {
+    $this->actingAs(createUser());
+});
+
+it('shows the resource to everyone by default', function (): void {
+    expect(WorkflowResource::canAccess())->toBeTrue();
+
+    $this->get('/admin/workflows')->assertOk();
+});
+
+it('hides the resource behind the plugin authorize callback', function (): void {
+    FlowPlugin::get()->authorize(fn (): bool => false);
+
+    expect(WorkflowResource::canAccess())->toBeFalse();
+
+    $this->get('/admin/workflows')->assertForbidden();
+
+    FlowPlugin::get()->authorize(fn (): bool => true);
+
+    expect(WorkflowResource::canAccess())->toBeTrue();
+});
+
+it('hides the resource behind the configured gate', function (): void {
+    config()->set('packstub-flow.gate', 'manage-workflows');
+    Gate::define('manage-workflows', fn ($user): bool => $user->email === 'boss@example.com');
+
+    expect(WorkflowResource::canAccess())->toBeFalse();
+
+    $this->actingAs(createUser(['email' => 'boss@example.com']));
+
+    expect(WorkflowResource::canAccess())->toBeTrue();
+});

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Carbon;
 use Packstub\Flow\Enums\RunStatus;
 use Packstub\Flow\Models\WorkflowRun;
@@ -49,4 +50,12 @@ it('publishes config and migrations through the install command', function (): v
     foreach (glob(database_path('migrations/*create_flow_tables.php')) as $file) {
         @unlink($file);
     }
+});
+
+it('schedules the prune command daily when retention is configured', function (): void {
+    $events = collect(app(Schedule::class)->events())
+        ->map(fn ($event): string => $event->command ?? '')
+        ->filter(fn (string $command): bool => str_contains($command, 'packstub-flow:prune'));
+
+    expect($events)->toHaveCount(1);
 });

--- a/tests/Feature/DefinitionValidatorTest.php
+++ b/tests/Feature/DefinitionValidatorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Livewire\Livewire;
+use Packstub\Flow\Filament\Resources\WorkflowResource\Pages\CreateWorkflow;
+use Packstub\Flow\Nodes\Actions\SendEmail;
+use Packstub\Flow\Nodes\Actions\WriteLog;
+use Packstub\Flow\Nodes\Triggers\Manual;
+use Packstub\Flow\Support\DefinitionValidator;
+use Packstub\Flow\Tests\Fixtures\SetStatusAction;
+
+it('accepts a connected workflow with its settings filled', function (): void {
+    $definition = ['nodes' => [triggerNode('t', Manual::class), actionNode('a', SetStatusAction::class, ['status' => 'x'])], 'edges' => [edge('t', 'a')]];
+
+    expect(DefinitionValidator::problems($definition))->toBe([]);
+});
+
+it('reports a missing trigger, unconnected nodes and empty required settings for an active workflow', function (): void {
+    $definition = ['nodes' => [actionNode('a', SetStatusAction::class), actionNode('b', WriteLog::class, ['message' => 'hi'])], 'edges' => []];
+
+    $problems = DefinitionValidator::problems($definition);
+
+    expect($problems)->toContain('Add at least one trigger before activating the workflow.')
+        ->toContain('Node "a" is not connected to anything before it.')
+        ->toContain('Node "b" is not connected to anything before it.')
+        ->toContain('Node "a": the setting "Status" is required.');
+});
+
+it('only checks node classes for an inactive workflow', function (): void {
+    $definition = ['nodes' => [actionNode('a', SetStatusAction::class), actionNode('x', 'App\\Nope')], 'edges' => []];
+
+    expect(DefinitionValidator::problems($definition, active: false))
+        ->toBe(['Node "x" uses a trigger, action or condition that is not registered.']);
+});
+
+it('blocks activating an incomplete workflow from the form', function (): void {
+    $this->actingAs(createUser());
+
+    $definition = ['nodes' => [triggerNode('t', Manual::class), actionNode('a', SendEmail::class)], 'edges' => []];
+
+    Livewire::test(CreateWorkflow::class)
+        ->fillForm(['name' => 'Broken', 'is_active' => true, 'definition' => $definition])
+        ->call('create')
+        ->assertHasFormErrors(['definition']);
+
+    Livewire::test(CreateWorkflow::class)
+        ->fillForm(['name' => 'Draft', 'is_active' => false, 'definition' => $definition])
+        ->call('create')
+        ->assertHasNoFormErrors();
+});

--- a/tests/Feature/DispatcherTest.php
+++ b/tests/Feature/DispatcherTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
 use Packstub\Flow\Enums\RunStatus;
 use Packstub\Flow\Facades\Flow;
@@ -103,4 +104,62 @@ it('returns null from run when the workflow has no trigger node', function (): v
     expect(Flow::run(manualWorkflow(), startNodeId: 'zzz')->status)->toBe(RunStatus::Failed);
 
     expect(Manual::make()->matches([], []))->toBeTrue();
+});
+
+it('fires a record updated trigger only when a watched attribute changes', function (): void {
+    createWorkflow([triggerNode('t', RecordUpdated::class, ['model_class' => Order::class, 'watch' => ['status']]), actionNode('a', SetStatusAction::class, ['status' => 'seen'])], [edge('t', 'a')]);
+
+    $order = createOrder();
+
+    $order->update(['total' => 250]);
+    expect(SetStatusAction::$calls)->toBe([]);
+
+    $order->update(['reference' => 'X', 'status' => 'paid']);
+    expect(SetStatusAction::$calls)->toHaveCount(1);
+});
+
+it('runs a workflow once per record when the trigger says so', function (): void {
+    createWorkflow([triggerNode('t', RecordUpdated::class, ['model_class' => Order::class, 'once' => true]), actionNode('a', SetStatusAction::class, ['status' => 'seen'])], [edge('t', 'a')]);
+
+    $order = createOrder();
+    $other = createOrder();
+
+    $order->update(['total' => 1]);
+    $order->update(['total' => 2]);
+    $other->update(['total' => 3]);
+
+    $runs = WorkflowRun::query()->get();
+
+    expect(SetStatusAction::$calls)->toHaveCount(2)
+        ->and($runs)->toHaveCount(2)
+        ->and($runs->pluck('subject_id')->all())->toBe([(string) $order->id, (string) $other->id])
+        ->and($runs->first()->subject_type)->toBe(Order::class)
+        ->and($runs->first()->subject()->is($order))->toBeTrue();
+});
+
+it('does not query the triggers table when no active workflow uses the trigger', function (): void {
+    createWorkflow([triggerNode('t', RecordCreated::class, ['model_class' => Order::class]), actionNode('a', SetStatusAction::class, ['status' => 'x'])], [edge('t', 'a')], ['is_active' => false]);
+
+    DB::enableQueryLog();
+
+    $order = createOrder();
+    $order->update(['total' => 5]);
+    $order->delete();
+
+    $queries = collect(DB::getQueryLog())->pluck('query')->filter(fn (string $sql): bool => str_contains($sql, 'flow_workflow_triggers'));
+
+    expect($queries)->toHaveCount(1);
+
+    DB::disableQueryLog();
+});
+
+it('rebuilds a payload from a run so it can be started again', function (): void {
+    $order = createOrder();
+    $run = Flow::run(manualWorkflow(), ['model' => $order, 'webhook' => ['id' => 5], 'user' => createUser()]);
+
+    $payload = $run->rebuildPayload();
+
+    expect($payload['model']->is($order))->toBeTrue()
+        ->and($payload['webhook'])->toBe(['id' => 5])
+        ->and($payload['user'])->toBeInstanceOf(User::class);
 });

--- a/tests/Feature/OutputsAndRetriesTest.php
+++ b/tests/Feature/OutputsAndRetriesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Packstub\Flow\Engine\Runner;
+use Packstub\Flow\Enums\RunStatus;
+use Packstub\Flow\Facades\Flow;
+use Packstub\Flow\Nodes\Actions\HttpRequest;
+use Packstub\Flow\Nodes\Conditions\CompareValues;
+use Packstub\Flow\Nodes\Triggers\Manual;
+use Packstub\Flow\Tests\Fixtures\FlakyAction;
+use Packstub\Flow\Tests\Fixtures\SetStatusAction;
+
+it('passes an action output down the branch as last and outputs', function (): void {
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('first', FlakyAction::class, ['value' => 'one']),
+        actionNode('second', FlakyAction::class, ['value' => 'two']),
+        actionNode('s', SetStatusAction::class, ['status' => '{{ last.value }}/{{ outputs.first.value }}/{{ last.seen }}']),
+    ], [edge('t', 'first'), edge('first', 'second'), edge('second', 's')]);
+
+    $run = Flow::run($workflow);
+
+    expect($run->status)->toBe(RunStatus::Success)
+        ->and(SetStatusAction::$calls[0]['payload']['last']['value'])->toBe('two')
+        ->and(SetStatusAction::$calls[0]['payload']['outputs']['first']['value'])->toBe('one')
+        ->and(SetStatusAction::$calls[0]['payload']['last']['seen'])->toBe(1)
+        ->and(collect($run->steps)->firstWhere('node_id', 'first')['output']['value'])->toBe('one')
+        ->and(collect($run->steps)->firstWhere('node_id', 'first'))->toHaveKeys(['duration_ms', 'status']);
+});
+
+it('exposes the HTTP response to the next nodes', function (): void {
+    Http::fake(['api.example.com/*' => Http::response(['id' => 'cust_9', 'vip' => true], 201)]);
+
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('h', HttpRequest::class, ['method' => 'GET', 'url' => 'https://api.example.com/customers/1']),
+        conditionNode('c', CompareValues::class, ['left' => '{{ last.body.vip }}', 'operator' => 'truthy']),
+        actionNode('s', SetStatusAction::class, ['status' => '{{ last.status }}:{{ last.body.id }}']),
+    ], [edge('t', 'h'), edge('h', 'c'), edge('c', 's', 'true')]);
+
+    $run = Flow::run($workflow);
+
+    expect($run->status)->toBe(RunStatus::Success)
+        ->and(SetStatusAction::$calls[0]['config']['status'])->toBe('{{ last.status }}:{{ last.body.id }}')
+        ->and(SetStatusAction::$calls[0]['payload']['last'])->toMatchArray(['status' => 201, 'ok' => true, 'body' => ['id' => 'cust_9', 'vip' => true]]);
+});
+
+it('branches keep their own outputs', function (): void {
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('a', FlakyAction::class, ['value' => 'A']),
+        actionNode('sa', SetStatusAction::class, ['status' => 'a']),
+        actionNode('sb', SetStatusAction::class, ['status' => 'b']),
+    ], [edge('t', 'a'), edge('a', 'sa'), edge('t', 'sb')]);
+
+    Flow::run($workflow);
+
+    expect(SetStatusAction::$calls[0]['payload']['last']['value'])->toBe('A')
+        ->and(SetStatusAction::$calls[1]['payload'])->not->toHaveKey('last');
+});
+
+it('runs a join node once when two branches reach it', function (): void {
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('a', SetStatusAction::class, ['status' => 'a']),
+        actionNode('b', SetStatusAction::class, ['status' => 'b']),
+        actionNode('join', SetStatusAction::class, ['status' => 'join']),
+    ], [edge('t', 'a'), edge('t', 'b'), edge('a', 'join'), edge('b', 'join')]);
+
+    $run = Flow::run($workflow);
+
+    expect($run->status)->toBe(RunStatus::Success)
+        ->and(array_column(SetStatusAction::$calls, 'config'))->toBe([['status' => 'a'], ['status' => 'join'], ['status' => 'b']]);
+});
+
+it('records the failing step with its error', function (): void {
+    $run = Flow::run(manualWorkflow(['status' => 'boom']));
+
+    $step = collect($run->steps)->firstWhere('node_id', 'a');
+
+    expect($run->status)->toBe(RunStatus::Failed)
+        ->and($step['status'])->toBe('failed')
+        ->and($step['message'])->toBe('Boom from the action');
+});
+
+it('retries an action the configured number of times', function (): void {
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('f', FlakyAction::class, ['fail_times' => 2, Runner::RETRIES => 2]),
+        actionNode('s', SetStatusAction::class, ['status' => 'ok']),
+    ], [edge('t', 'f'), edge('f', 's')]);
+
+    $run = Flow::run($workflow);
+
+    expect($run->status)->toBe(RunStatus::Success)
+        ->and(FlakyAction::$attempts)->toBe(3)
+        ->and(collect($run->steps)->where('status', 'retry')->count())->toBe(2)
+        ->and(SetStatusAction::$calls)->toHaveCount(1)
+        ->and(FlakyAction::$attempts)->toBe(3);
+});
+
+it('fails the run when retries are exhausted', function (): void {
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('f', FlakyAction::class, ['fail_times' => 5, Runner::RETRIES => 1]),
+        actionNode('s', SetStatusAction::class, ['status' => 'ok']),
+    ], [edge('t', 'f'), edge('f', 's')]);
+
+    $run = Flow::run($workflow);
+
+    expect($run->status)->toBe(RunStatus::Failed)
+        ->and(FlakyAction::$attempts)->toBe(2)
+        ->and(SetStatusAction::$calls)->toBe([]);
+});
+
+it('continues after a failure when the node says so', function (): void {
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('f', FlakyAction::class, ['fail_times' => 5, Runner::ON_ERROR => 'continue']),
+        actionNode('s', SetStatusAction::class, ['status' => 'still-ran']),
+    ], [edge('t', 'f'), edge('f', 's')]);
+
+    $run = Flow::run($workflow);
+
+    $step = collect($run->steps)->firstWhere('node_id', 'f');
+
+    expect($run->status)->toBe(RunStatus::Success)
+        ->and($step['status'])->toBe('failed')
+        ->and(SetStatusAction::$calls)->toHaveCount(1)
+        ->and(SetStatusAction::$calls[0]['config'])->toBe(['status' => 'still-ran']);
+});
+
+it('strips the runner settings from the config an action receives', function (): void {
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('s', SetStatusAction::class, ['status' => 'x', Runner::RETRIES => 1, Runner::RETRY_AFTER => 0, Runner::ON_ERROR => 'fail']),
+    ], [edge('t', 's')]);
+
+    Flow::run($workflow);
+
+    expect(SetStatusAction::$calls[0]['config'])->toBe(['status' => 'x']);
+});

--- a/tests/Feature/PanelTest.php
+++ b/tests/Feature/PanelTest.php
@@ -133,3 +133,18 @@ it('validates node settings', function (): void {
         ->callMountedAction()
         ->assertHasActionErrors(['label', 'recipient']);
 });
+
+it('runs a finished run again with the same payload', function (): void {
+    $order = createOrder();
+    $workflow = manualWorkflow(['status' => 'again']);
+    $run = Flow::run($workflow, ['model' => $order]);
+
+    Livewire::test(RunsRelationManager::class, ['ownerRecord' => $workflow, 'pageClass' => EditWorkflow::class])
+        ->callTableAction('rerun', $run)
+        ->assertNotified();
+
+    expect(WorkflowRun::query()->count())->toBe(2)
+        ->and(SetStatusAction::$calls)->toHaveCount(2)
+        ->and(SetStatusAction::$calls[1]['payload']['model']->is($order))->toBeTrue()
+        ->and(WorkflowRun::query()->latest('started_at')->first()->subject_id)->toBe((string) $order->id);
+});

--- a/tests/Feature/PlaceholdersTest.php
+++ b/tests/Feature/PlaceholdersTest.php
@@ -45,3 +45,38 @@ it('resolves a bare path to its raw value', function (): void {
         ->and(Placeholders::hasPlaceholders('{{ a.b }}'))->toBeTrue()
         ->and(Placeholders::hasPlaceholders('plain'))->toBeFalse();
 });
+
+it('applies filters to placeholder values', function (): void {
+    $order = createOrder(['created_at' => '2026-09-02 08:30:00', 'total' => 1234.5]);
+    $payload = ['model' => $order, 'tags' => ['a', 'b'], 'empty' => null];
+
+    expect(Placeholders::render('{{ model.created_at | date:Y-m-d }}', $payload))->toBe('2026-09-02')
+        ->and(Placeholders::render('{{ model.created_at | date:H\\:i }}', $payload))->toBe('08:30')
+        ->and(Placeholders::render('{{ model.status | upper }}', $payload))->toBe('PENDING')
+        ->and(Placeholders::render('{{ model.status | title }}', $payload))->toBe('Pending')
+        ->and(Placeholders::render('{{ model.total | number:2 }}', $payload))->toBe('1,234.50')
+        ->and(Placeholders::render('{{ empty | default:none }}', $payload))->toBe('none')
+        ->and(Placeholders::render('{{ model.status | default:none }}', $payload))->toBe('pending')
+        ->and(Placeholders::render('{{ tags | count }}', $payload))->toBe('2')
+        ->and(Placeholders::render('{{ tags | join:-- }}', $payload))->toBe('a--b')
+        ->and(Placeholders::render('{{ tags | first | upper }}', $payload))->toBe('A')
+        ->and(Placeholders::render('{{ tags | json }}', $payload))->toBe('["a","b"]')
+        ->and(Placeholders::render('{{ model.reference | truncate:5 }}', $payload))->toBe('ORD-0...')
+        ->and(Placeholders::render('{{ model.status | unknown }}', $payload))->toBe('pending');
+});
+
+it('never exposes hidden model attributes', function (): void {
+    $user = createUser();
+    $order = createOrder(['user_id' => $user->id]);
+
+    expect(Placeholders::render('[{{ model.password }}][{{ model.remember_token }}][{{ model.name }}]', ['model' => $user]))->toBe("[][][{$user->name}]")
+        ->and(Placeholders::render('{{ model.user.password }}', ['model' => $order]))->toBe('')
+        ->and(Placeholders::raw('{{ model.password }}', ['model' => $user]))->toBeNull();
+});
+
+it('resolves a single placeholder to its raw value', function (): void {
+    expect(Placeholders::raw('{{ a.b }}', ['a' => ['b' => [1, 2]]]))->toBe([1, 2])
+        ->and(Placeholders::raw(' {{ n }} ', ['n' => 5]))->toBe(5)
+        ->and(Placeholders::raw('x {{ n }}', ['n' => 5]))->toBeNull()
+        ->and(Placeholders::isSingle('{{ n | upper }}'))->toBeTrue();
+});

--- a/tests/Feature/ScheduleTest.php
+++ b/tests/Feature/ScheduleTest.php
@@ -32,3 +32,12 @@ it('validates the expression', function (): void {
         ->and((new Schedule)->matches(['expression' => 'nope'], []))->toBeFalse()
         ->and((new Schedule)->matches([], []))->toBeFalse();
 });
+
+it('evaluates the expression in the trigger timezone', function (): void {
+    $schedule = new Schedule;
+    $now = Carbon::parse('2026-09-02 09:00:00', 'UTC');
+
+    expect($schedule->matches(['expression' => '0 9 * * *'], ['now' => $now]))->toBeTrue()
+        ->and($schedule->matches(['expression' => '0 9 * * *', 'timezone' => 'Europe/Bucharest'], ['now' => $now]))->toBeFalse()
+        ->and($schedule->matches(['expression' => '0 12 * * *', 'timezone' => 'Europe/Bucharest'], ['now' => $now]))->toBeTrue();
+});

--- a/tests/Feature/UrlGuardTest.php
+++ b/tests/Feature/UrlGuardTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Packstub\Flow\Exceptions\WorkflowException;
+use Packstub\Flow\Nodes\Actions\HttpRequest;
+use Packstub\Flow\Nodes\Actions\SendSlackMessage;
+use Packstub\Flow\Support\UrlGuard;
+
+beforeEach(function (): void {
+    config()->set('packstub-flow.http.block_private_networks', true);
+});
+
+it('refuses private, loopback and link-local addresses', function (string $url): void {
+    expect(fn () => UrlGuard::assertAllowed($url))->toThrow(WorkflowException::class);
+})->with([
+    'http://127.0.0.1/admin',
+    'http://localhost:8000/',
+    'http://app.localhost/',
+    'http://10.0.0.5/',
+    'http://192.168.1.1/',
+    'http://172.16.0.1/',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://[::1]/',
+    'http://0.0.0.0/',
+]);
+
+it('refuses schemes other than http and https', function (): void {
+    expect(fn () => UrlGuard::assertAllowed('file:///etc/passwd'))->toThrow(WorkflowException::class)
+        ->and(fn () => UrlGuard::assertAllowed('ftp://example.com'))->toThrow(WorkflowException::class)
+        ->and(fn () => UrlGuard::assertAllowed('not a url'))->toThrow(WorkflowException::class);
+});
+
+it('allows public addresses and honours the allowed hosts list', function (): void {
+    UrlGuard::assertAllowed('https://93.184.216.34/');
+
+    config()->set('packstub-flow.http.allowed_hosts', ['api.example.com', '*.hooks.example.org']);
+
+    UrlGuard::assertAllowed('https://api.example.com/v1');
+    UrlGuard::assertAllowed('https://eu.hooks.example.org/x');
+    UrlGuard::assertAllowed('https://hooks.example.org/x');
+
+    expect(fn () => UrlGuard::assertAllowed('https://evil.example.com/'))->toThrow(WorkflowException::class)
+        ->and(fn () => UrlGuard::assertAllowed('https://127.0.0.1/'))->toThrow(WorkflowException::class);
+});
+
+it('can be switched off', function (): void {
+    config()->set('packstub-flow.http.block_private_networks', false);
+
+    UrlGuard::assertAllowed('http://127.0.0.1/');
+
+    expect(true)->toBeTrue();
+});
+
+it('guards the HTTP request and Slack actions', function (): void {
+    Http::fake();
+
+    expect(fn () => (new HttpRequest)->handle(['method' => 'GET', 'url' => 'http://169.254.169.254/'], []))->toThrow(WorkflowException::class)
+        ->and(fn () => (new SendSlackMessage)->handle(['webhook_url' => 'http://localhost/hook', 'message' => 'x'], []))->toThrow(WorkflowException::class);
+
+    Http::assertNothingSent();
+});

--- a/tests/Feature/WaitTest.php
+++ b/tests/Feature/WaitTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Queue;
 use Packstub\Flow\Enums\RunStatus;
 use Packstub\Flow\Facades\Flow;
@@ -124,4 +125,45 @@ it('uses a snapshot of the graph taken when the wait started', function (): void
     Queue::pushedJobs()[ResumeWorkflowJob::class][0]['job']->handle();
 
     expect(SetStatusAction::$calls[0]['config']['status'])->toBe('original');
+});
+
+it('waits until a date from the payload with an offset', function (): void {
+    Date::setTestNow('2026-09-02 10:00:00');
+
+    $wait = new Wait;
+    $order = createOrder(['created_at' => '2026-09-03 10:00:00']);
+
+    expect($wait->getDelaySeconds(['mode' => 'until', 'until' => '{{ model.created_at }}', 'duration' => 1, 'unit' => 'hours', 'direction' => 'before'], ['model' => $order]))->toBe(23 * 3600)
+        ->and($wait->getDelaySeconds(['mode' => 'until', 'until' => '{{ model.created_at }}', 'duration' => 2, 'unit' => 'hours', 'direction' => 'after'], ['model' => $order]))->toBe(26 * 3600)
+        ->and($wait->getDelaySeconds(['mode' => 'until', 'until' => '2026-09-02 10:30:00', 'duration' => 0], []))->toBe(1800)
+        ->and($wait->getDelaySeconds(['mode' => 'until', 'until' => '{{ model.created_at }}', 'duration' => 3, 'unit' => 'days', 'direction' => 'before'], ['model' => $order]))->toBeNull()
+        ->and($wait->getDelaySeconds(['mode' => 'until', 'until' => '{{ missing }}', 'duration' => 1, 'unit' => 'days'], []))->toBeNull()
+        ->and($wait->getDelaySeconds(['mode' => 'until', 'until' => 'not a date'], []))->toBeNull();
+
+    Date::setTestNow();
+});
+
+it('does not resume a run that another branch already failed', function (): void {
+    Queue::fake();
+
+    $workflow = createWorkflow([
+        triggerNode('t', Manual::class),
+        actionNode('w', Wait::class, ['duration' => 1, 'unit' => 'minutes']),
+        actionNode('after', SetStatusAction::class, ['status' => 'after']),
+        actionNode('boom', SetStatusAction::class, ['status' => 'boom']),
+    ], [edge('t', 'w'), edge('w', 'after'), edge('t', 'boom')]);
+
+    $run = Flow::run($workflow);
+
+    expect($run->status)->toBe(RunStatus::Failed);
+
+    Queue::assertPushed(ResumeWorkflowJob::class, function (ResumeWorkflowJob $job): bool {
+        $job->handle();
+
+        return true;
+    });
+
+    expect($run->fresh()->status)->toBe(RunStatus::Failed)
+        ->and($run->fresh()->pending_resumes)->toBe(0)
+        ->and(collect(SetStatusAction::$calls)->pluck('config.status')->all())->toBe(['boom']);
 });

--- a/tests/Feature/WebhookTest.php
+++ b/tests/Feature/WebhookTest.php
@@ -48,3 +48,45 @@ it('the trigger compares tokens in constant time and refuses empty ones', functi
         ->and($trigger->matches(['token' => 'abc'], ['webhook_token' => 'abd']))->toBeFalse()
         ->and($trigger->matches([], ['webhook_token' => 'abc']))->toBeFalse();
 });
+
+it('verifies an HMAC signature when the trigger has a signing secret', function (): void {
+    $workflow = createWorkflow([
+        triggerNode('t', Webhook::class, ['token' => 'secret-token-1234567890', 'signing_secret' => 'shh']),
+        actionNode('a', SetStatusAction::class, ['status' => 'ok']),
+    ], [edge('t', 'a')]);
+
+    $body = json_encode(['order' => ['status' => 'paid']]);
+    $signature = hash_hmac('sha256', $body, 'shh');
+
+    $this->call('POST', "/flow/webhooks/{$workflow->id}/secret-token-1234567890", [], [], [], ['CONTENT_TYPE' => 'application/json'], $body)
+        ->assertStatus(401);
+
+    $this->call('POST', "/flow/webhooks/{$workflow->id}/secret-token-1234567890", [], [], [], ['CONTENT_TYPE' => 'application/json', 'HTTP_X_SIGNATURE' => 'nope'], $body)
+        ->assertStatus(401);
+
+    $this->call('POST', "/flow/webhooks/{$workflow->id}/secret-token-1234567890", [], [], [], ['CONTENT_TYPE' => 'application/json', 'HTTP_X_SIGNATURE' => "sha256={$signature}"], $body)
+        ->assertStatus(202);
+
+    expect(SetStatusAction::$calls)->toHaveCount(1)
+        ->and(Webhook::verifySignature(['signing_secret' => 'shh', 'signature_header' => 'X-Hub'], 'abc', hash_hmac('sha256', 'abc', 'shh')))->toBeTrue()
+        ->and(Webhook::signatureHeader(['signature_header' => 'X-Hub']))->toBe('X-Hub')
+        ->and(Webhook::signatureHeader([]))->toBe('X-Signature');
+});
+
+it('drops credential headers from the stored payload', function (): void {
+    $workflow = webhookWorkflow();
+
+    $this->postJson("/flow/webhooks/{$workflow->id}/secret-token-1234567890", ['order' => ['status' => 'x']], [
+        'Authorization' => 'Bearer top-secret',
+        'Cookie' => 'session=abc',
+        'X-Api-Key' => 'k',
+        'X-Request-Id' => 'req-1',
+    ])->assertStatus(202);
+
+    $headers = SetStatusAction::$calls[0]['payload']['headers'];
+    $context = WorkflowRun::query()->first()->context;
+
+    expect($headers)->toHaveKey('x-request-id')
+        ->and($headers)->not->toHaveKeys(['authorization', 'cookie', 'x-api-key'])
+        ->and(json_encode($context))->not->toContain('top-secret');
+});

--- a/tests/Fixtures/AdminPanelProvider.php
+++ b/tests/Fixtures/AdminPanelProvider.php
@@ -43,7 +43,7 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->plugin(
                 FlowPlugin::make()
-                    ->actions([SetStatusAction::class])
+                    ->actions([SetStatusAction::class, FlakyAction::class])
                     ->navigationGroup('Automation'),
             );
     }

--- a/tests/Fixtures/FlakyAction.php
+++ b/tests/Fixtures/FlakyAction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Packstub\Flow\Tests\Fixtures;
+
+use Filament\Forms\Components\TextInput;
+use Packstub\Flow\Nodes\Action;
+
+/**
+ * Fails the first `fail_times` calls, then succeeds and exposes an output.
+ */
+class FlakyAction extends Action
+{
+    public static int $attempts = 0;
+
+    public function getName(): string
+    {
+        return 'Flaky';
+    }
+
+    public function getFormSchema(): array
+    {
+        return [TextInput::make('fail_times')->numeric()];
+    }
+
+    public function handle(array $config, array $payload): void
+    {
+        static::$attempts++;
+
+        if (static::$attempts <= (int) ($config['fail_times'] ?? 0)) {
+            throw new \RuntimeException("Attempt {$config['fail_times']} not reached yet");
+        }
+
+        $this->output(['attempts' => static::$attempts, 'seen' => $payload['last']['attempts'] ?? null, 'value' => $config['value'] ?? 'v']);
+    }
+}

--- a/tests/Fixtures/GuardedOrder.php
+++ b/tests/Fixtures/GuardedOrder.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Packstub\Flow\Tests\Fixtures;
+
+/**
+ * An order whose status cannot be mass-assigned.
+ */
+class GuardedOrder extends Order
+{
+    protected $guarded = ['status'];
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Hash;
 use Packstub\Flow\Models\Workflow;
 use Packstub\Flow\Nodes\Triggers\Manual;
+use Packstub\Flow\Tests\Fixtures\FlakyAction;
 use Packstub\Flow\Tests\Fixtures\Order;
 use Packstub\Flow\Tests\Fixtures\SetStatusAction;
 use Packstub\Flow\Tests\Fixtures\User;
@@ -12,6 +13,7 @@ pest()->extend(TestCase::class)->in('Feature');
 
 pest()->beforeEach(function (): void {
     SetStatusAction::$calls = [];
+    FlakyAction::$attempts = 0;
 });
 
 /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Packstub\Flow\Engine\Dispatcher;
 use Packstub\Flow\FlowServiceProvider;
 use Packstub\Flow\Listeners\DispatchEventTriggers;
 use Packstub\Flow\Support\ModelFinder;
@@ -33,6 +34,7 @@ abstract class TestCase extends Orchestra
         $this->migrate();
 
         DispatchEventTriggers::flush();
+        Dispatcher::flushCache();
         ModelFinder::flush();
     }
 
@@ -72,6 +74,7 @@ abstract class TestCase extends Orchestra
         $app['config']->set('mail.default', 'array');
         $app['config']->set('queue.default', 'sync');
         $app['config']->set('packstub-flow.models_for_triggers', [Fixtures\Order::class]);
+        $app['config']->set('packstub-flow.http.block_private_networks', false);
     }
 
     protected function migrate(): void


### PR DESCRIPTION
## Why

A production-readiness audit and a competitive review of the plugin (notes in `workspace/notes/filament-flow/`) found that v1.0.0 was well tested for its size but only safe for a single trusted admin, and lacked the engine features that make an automation builder useful in practice: using an HTTP response later in the flow, retrying a flaky step, "only when status changes", "once per customer", "1 day before the appointment". This PR closes the security blockers and adds those features.

## Security

- **Outgoing requests are guarded** (`Support/UrlGuard`): `HTTP request` and `Send Slack message` refuse non-http(s) URLs and hosts that resolve to loopback/private/link-local/reserved addresses; `http.allowed_hosts` restricts destinations further. Requests get a timeout (`http.timeout`, 15 s) and optional per-node retries; placeholder values in URLs are URL-encoded; JSON bodies are built through a tokeniser so a placeholder value cannot add keys.
- **`Update record` respects `$fillable` / `$guarded`** and fails the run naming the guarded attribute; a per-node *Bypass mass-assignment protection* toggle restores `forceFill()`.
- **Hidden model attributes** never resolve in placeholders, even through relations.
- **Webhook payloads drop credential headers** (`webhooks.redacted_headers`) before they are stored on the run; webhook nodes can require an **HMAC-SHA256 signature** (`401` otherwise).
- **Authorization**: `FlowPlugin::make()->authorize(fn () => ...)` and `packstub-flow.gate`, on top of any `Workflow` policy.

## Engine

- **Action outputs**: `$this->output([...])` → `{{ last.* }}` / `{{ outputs.<node id>.* }}` for the rest of the branch; `HttpRequest` exposes `status`, `ok`, `body`, `headers`, `UpdateRecord` exposes `changes`. Payload travels per branch; a join node reached by two branches runs once.
- **Per-node error handling** (`_retries`, `_retry_after`, `_on_error`) with an *Error handling* section in the node slide-over.
- **Step log** entries carry `status`, `duration_ms`, `output`, and the error on the failing step; appends are re-read under a lock so concurrent resumes do not clobber each other; a resume for a run another branch already failed does nothing.
- **Jobs** implement `ShouldQueueAfterCommit`, `tries = 1`, configurable `timeout`.
- **Record-trigger dispatch is cached**: model saves no longer query the triggers table unless an active workflow has a trigger of that type.
- **Placeholder filters**: `date`, `upper`, `lower`, `title`, `trim`, `truncate`, `number`, `default`, `json`, `count`, `join`, `first`, `last`.

## Nodes and panel

- `Record updated` → *Only when these attributes change*; record triggers → *Run once per record* (runs store `subject_type` / `subject_id`).
- `Wait` → *Until a date from the payload* with an offset before/after.
- `Schedule` → per-trigger timezone.
- **Run again** on finished runs; run details show timings and outputs.
- **Definition validation** before saving an active workflow (trigger present, nodes connected, required settings filled); `FlowBuilder::withoutValidation()` opts out.
- `packstub-flow:prune` scheduled daily; indexes on the runs table.

## Notes for review

- Migration stub changed (new `subject_*` columns and indexes). v1.0.0 was tagged today with no installs, so the stub is edited in place; the demo app needs `migrate:fresh --seed`.
- No Svelte changes; `resources/dist` untouched.
- Docs, README and CHANGELOG updated for everything above.

## Tests

`composer test`: 143 passed (492 assertions), up from 95 / 337. Pint clean. New: `OutputsAndRetriesTest`, `UrlGuardTest`, `AuthorizationTest`, `DefinitionValidatorTest`, plus cases in the actions, dispatcher, wait, webhook, placeholders, schedule, panel and commands suites.
