### PR TITLE
GitHub release on every v* tag

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,59 @@
+name: GitHub release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)create the release for, e.g. v1.0.1"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release from CHANGELOG.md
+    runs-on: ubuntu-latest
+
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
+      # Matches "## 1.2.3 — date" and Keep-a-Changelog "## [1.2.3] - date".
+      - name: Extract the changelog section for this tag
+        run: |
+          version="${TAG#v}"
+          if [ -f CHANGELOG.md ]; then
+            awk -v v="$version" '
+              /^## / { printing = ($0 ~ ("^## \\[?v?" v "(\\]| |$)")) ; next }
+              printing { print }
+            ' CHANGELOG.md | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > release-notes.md
+          else
+            : > release-notes.md
+          fi
+          if [ -s release-notes.md ]; then
+            echo "Notes from CHANGELOG.md:"; cat release-notes.md
+          else
+            echo "No \"## $version\" section in CHANGELOG.md; GitHub will generate the notes from the commits."
+          fi
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; skipping."
+            exit 0
+          fi
+          if [ -s release-notes.md ]; then
+            gh release create "$TAG" --title "$TAG" --notes-file release-notes.md --verify-tag
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes --verify-tag
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,5 @@ bun run build               # rebuilds resources/dist (flow.js, flow.css) — co
 ## Conventions
 
 - PHP 8.3+, Pint, Pest; every change needs a test. Keep `CHANGELOG.md` current.
+- Release = a `## <version>` heading in `CHANGELOG.md`, then a `v<version>` tag on `main`. `.github/workflows/github-release.yml` creates the GitHub release from that changelog section (manual run with a `tag` input for backfills) — no manual release step.
 - Listing assets/copy: use the `filament-plugin-listing` skill from the workspace root.


### PR DESCRIPTION
Adds `.github/workflows/github-release.yml`: on a `v*` tag push (or a manual run with a `tag` input, for backfills) it extracts the matching `## <version>` section of `CHANGELOG.md` and creates the GitHub release with it; falls back to GitHub-generated notes when there is no section; skips if the release already exists. AGENTS.md documents the release path. Same workflow as packstub/filament-agents#5.