### PR TITLE
Pin release checkout to SHA, add bun to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,20 @@ updates:
       default-days: 7
     labels:
       - "dependencies"
+
+  # Svelte canvas build tooling (bun.lock); the built output lives in resources/dist.
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    labels:
+      - "dependencies"
+    groups:
+      javascript:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -22,7 +22,7 @@ jobs:
       TAG: ${{ inputs.tag || github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 


### PR DESCRIPTION
Fixes the two filamentphp.com package-health warnings (92/100 → 100):

- `github-release.yml` used `actions/checkout@v7`; now pinned to the same SHA as the other workflows.
- Dependabot did not cover the JavaScript ecosystem although `bun.lock` is committed; added a weekly `bun` entry with a 7-day cooldown and grouped minor/patch updates.