### PR TITLE
Group Dependabot action updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       default-days: 7
     labels:
       - "dependencies"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   # Svelte canvas build tooling (bun.lock); the built output lives in resources/dist.
   - package-ecosystem: "bun"


### PR DESCRIPTION
One PR per check instead of one per action, so CI runs once per update round. Weekly schedule and 7-day cooldown unchanged.